### PR TITLE
Update Name + Beta release errata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # build artifacts
-sketch-auto-spec.sketchplugin
+sketch-speccing.sketchplugin
 
 # npm
 node_modules

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# sketch-auto-spec
+# sketch-speccing
 
 ## Installation
 
-- [Download](../../releases/latest/download/sketch-auto-spec.sketchplugin.zip) the latest release of the plugin
+- [Download](../../releases/latest/download/sketch-speccing.sketchplugin.zip) the latest release of the plugin
 - Un-zip
-- Double-click on sketch-auto-spec.sketchplugin
+- Double-click on sketch-speccing.sketchplugin
 
 ## Development Guide
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "sketch-auto-spec",
+  "name": "sketch-speccing",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sketch-auto-spec",
+  "name": "sketch-speccing",
   "description": "A Sketch plugin for easily spec’ing design system components.",
   "version": "0.1.0",
   "repository": {
@@ -27,9 +27,9 @@
   },
   "pre-commit": "lint:staged",
   "skpm": {
-    "name": "sketch-auto-spec",
+    "name": "sketch-speccing",
     "manifest": "src/manifest.json",
-    "main": "sketch-auto-spec.sketchplugin",
+    "main": "sketch-speccing.sketchplugin",
     "assets": [
       "assets/**/*"
     ],

--- a/resources/style.css
+++ b/resources/style.css
@@ -100,6 +100,7 @@ svg {
   display: block;
   margin-right: 13px;
   width: 25px; /* 19px icon */
+  opacity: 0.5; /* temporarily disable measure */
 }
 
 /* buttons */
@@ -129,6 +130,15 @@ svg polygon {
   a:hover svg path,
   a:hover svg polygon {
     fill: rgba(0, 0, 0, 0.9);
+  }
+
+  /* temporarily disable measure */
+  .actions li.action-measure a:hover {
+    cursor: default;
+  }
+
+  .actions li.action-measure a:hover svg polygon {
+    fill: rgba(0, 0, 0, 0.6);
   }
 }
 

--- a/resources/webview.js
+++ b/resources/webview.js
@@ -64,8 +64,9 @@ const AutoSpecWebview = {
     const triggerElements = document.querySelectorAll('.action-trigger');
 
     /**
-     * @description Takes a string message and logs it at one of 2 levels (normal or error).
-     * WIP
+     * @description Adds a click event listener to each webview trigger (`.action-trigger`)
+     * and fires off the appropriate action(s) when clicked.
+     *
      * @kind function
      * @param {array} triggerElements Array containing the UI elements to watch for input.
      */

--- a/resources/webview.js
+++ b/resources/webview.js
@@ -65,12 +65,13 @@ const AutoSpecWebview = {
 
     /**
      * @description Takes a string message and logs it at one of 2 levels (normal or error).
-     *
+     * WIP
      * @kind function
      * @param {array} triggerElements Array containing the UI elements to watch for input.
      */
     Array.from(triggerElements).forEach((trigger) => {
       document.getElementById(trigger.id).addEventListener('click', () => {
+        window.postMessage('nativeLog', `Called #${trigger.id} from the GUI`);
         switch (trigger.id) {
           case 'close':
             window.postMessage('closeWindow');
@@ -79,7 +80,7 @@ const AutoSpecWebview = {
             window.postMessage('labelLayer');
             break;
           default:
-            window.postMessage('nativeLog', `Called #${trigger.id} from the webview`);
+            window.postMessage('nativeLog', `Missing ${trigger.id} action`);
         }
         return null;
       });

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -19,10 +19,9 @@ const webviewIdentifier = `${PLUGIN_IDENTIFIER}.webview`;
 
 /**
  * @description Set up a new Messenger class instance.
- * WIP
+ *
  * @kind function
  * @name messenger
- * @param {Object}
  */
 const messenger = new Messenger({ for: { action: 'GUI' } });
 

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -1,9 +1,9 @@
 /**
  * @description A set of functions to operate the plugin GUI.
  */
-import UI from 'sketch/ui'; // eslint-disable-line import/no-unresolved
 import BrowserWindow from 'sketch-module-web-view';
 import { getWebview } from 'sketch-module-web-view/remote';
+import Messenger from './Messenger';
 import * as theWebview from '../resources/webview.html';
 import { labelLayer } from './main';
 
@@ -15,6 +15,15 @@ import { labelLayer } from './main';
  * @type {string}
  */
 const webviewIdentifier = 'com.linkedinlabs.sketch.auto-spec-plugin.webview';
+
+/**
+ * @description Set up a new Messenger class instance.
+ * WIP
+ * @kind function
+ * @name messenger
+ * @param {Object}
+ */
+const messenger = new Messenger({ for: { action: 'GUI' } });
 
 /**
  * @description Called by the plugin manifest to open and operate the UI.
@@ -68,11 +77,14 @@ const watchGui = () => {
    */
   const { webContents } = browserWindow;
 
-  // print a message when the page loads
-  webContents.on('did-finish-load', () => UI.message('UI loaded!'));
+  // log a message when the view loads
+  webContents.on('did-finish-load', () => messenger.log('GUI loaded!'));
 
   // add a handler for a call from web content's javascript
-  webContents.on('nativeLog', message => UI.message(message));
+  webContents.on('nativeLog', (message) => {
+    messenger.log(message);
+  });
+
 
   // call the labelLayer function in main.js
   webContents.on('labelLayer', () => labelLayer());
@@ -82,6 +94,7 @@ const watchGui = () => {
     const existingWebview = getWebview(webviewIdentifier);
     if (existingWebview) {
       existingWebview.close();
+      messenger.log('GUI closed.');
     }
   });
 
@@ -100,5 +113,6 @@ export const onShutdown = () => {
   const existingWebview = getWebview(webviewIdentifier);
   if (existingWebview) {
     existingWebview.close();
+    messenger.log('GUI closed.');
   }
 };

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -6,6 +6,7 @@ import { getWebview } from 'sketch-module-web-view/remote';
 import Messenger from './Messenger';
 import * as theWebview from '../resources/webview.html';
 import { labelLayer } from './main';
+import { PLUGIN_IDENTIFIER } from './constants';
 
 /**
  * @description The namespace constant used to identify the webview within Sketch.
@@ -14,7 +15,7 @@ import { labelLayer } from './main';
  * @name webviewIdentifier
  * @type {string}
  */
-const webviewIdentifier = 'com.linkedinlabs.sketch.auto-spec-plugin.webview';
+const webviewIdentifier = `${PLUGIN_IDENTIFIER}.webview`;
 
 /**
  * @description Set up a new Messenger class instance.

--- a/src/Messenger.js
+++ b/src/Messenger.js
@@ -34,7 +34,7 @@ export default class Messenger {
     const documentIdString = this.document ? ` ${this.document.id} :` : '';
     const eventTypeString = this.event ? ` ${this.event.action} :` : 'Invoked';
 
-    log(`Auto-Spec ${logType}${documentIdString}${eventTypeString} ${message}`);
+    log(`Spec’ing ${logType}${documentIdString}${eventTypeString} ${message}`);
   }
 
   /**

--- a/src/Messenger.js
+++ b/src/Messenger.js
@@ -31,14 +31,10 @@ export default class Messenger {
    */
   log(message, type = 'normal') {
     const logType = type === 'error' ? '🆘' : '🐞';
+    const documentIdString = this.document ? ` ${this.document.id} :` : '';
+    const eventTypeString = this.event ? ` ${this.event.action} :` : 'Invoked';
 
-    let eventType = 'GUI';
-    if (this.event) {
-      eventType = this.event.action ? this.event.action : 'Invoked';
-    }
-
-    // log(this.event);
-    log(`Auto-Spec ${logType} ${this.document.id} : ${eventType} : ${message}`);
+    log(`Auto-Spec ${logType}${documentIdString}${eventTypeString} ${message}`);
   }
 
   /**

--- a/src/Messenger.js
+++ b/src/Messenger.js
@@ -1,4 +1,5 @@
 import { UI } from 'sketch';
+import { PLUGIN_NAME } from './constants';
 
 /**
  * @description A class to handle UI alerts, messages, and logging.
@@ -34,7 +35,7 @@ export default class Messenger {
     const documentIdString = this.document ? ` ${this.document.id} :` : '';
     const eventTypeString = this.event ? ` ${this.event.action} :` : 'Invoked';
 
-    log(`Spec’ing ${logType}${documentIdString}${eventTypeString} ${message}`);
+    log(`${PLUGIN_NAME} ${logType}${documentIdString}${eventTypeString} ${message}`);
   }
 
   /**

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -6,7 +6,7 @@ import {
   Text,
 } from 'sketch/dom';
 import { findLayerById } from './Tools';
-import { PLUGIN_IDENTIFIER } from './constants';
+import { PLUGIN_IDENTIFIER, PLUGIN_NAME } from './constants';
 
 // --- settings/state management
 // good candidate to move this all to its own class once it gets re-used
@@ -81,7 +81,8 @@ const updateSettings = (key, data, action = 'add') => {
     settings[key] = updatedItems;
   }
 
-  settings = Settings.setSettingForKey(PLUGIN_IDENTIFIER, settings);
+  Settings.setSettingForKey(PLUGIN_IDENTIFIER, settings);
+  log(settings);
   return settings;
 };
 
@@ -297,7 +298,7 @@ const createContainerGroup = (artboard) => {
       height: artboard.frame().height(),
     },
     locked: true,
-    name: '+++ Spec’ing Labels +++',
+    name: `+++ ${PLUGIN_NAME} Labels +++`,
     parent: artboard,
   });
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -82,7 +82,6 @@ const updateSettings = (key, data, action = 'add') => {
   }
 
   Settings.setSettingForKey(PLUGIN_IDENTIFIER, settings);
-  log(settings);
   return settings;
 };
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -86,7 +86,7 @@ export default class Painter {
         height: this.artboard.frame().height(),
       },
       locked: true,
-      name: '+++ Auto-Spec Labels +++',
+      name: '+++ Spec’ing Labels +++',
       parent: this.artboard,
     });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,13 +3,24 @@
 /**
  * @description A constant with unique string to identify the plugin within Sketch.
  * Changing this will potentially break data retrieval in Sketch files that used
- * earlier versions of the plugin with a different identifier.
+ * earlier versions of the plugin with a different identifier. This should match the
+ * `identifier` stated in manifset.json.
  *
  * @kind constant
- * @name options
+ * @name PLUGIN_IDENTIFIER
  * @type {string}
  */
 const PLUGIN_IDENTIFIER = 'com.linkedinlabs.sketch.auto-spec-plugin';
 
-export { PLUGIN_IDENTIFIER };
+/**
+ * @description The public-facing name for the plugin. This should match the
+ * `name` stated in manifset.json.
+ *
+ * @kind constant
+ * @name PLUGIN_NAME
+ * @type {string}
+ */
+const PLUGIN_NAME = 'Spec’ing';
+
+export { PLUGIN_IDENTIFIER, PLUGIN_NAME };
 /* eslint-enable import/prefer-default-export */

--- a/src/main.js
+++ b/src/main.js
@@ -127,15 +127,8 @@ const onOpenDocument = (context) => {
 const onSelectionChange = (context) => {
   if (String(context.action) === 'SelectionChanged.finish') {
     const { document, messenger } = assemble(context);
-    // const newSelectionArray = setArray(context.actionContext.newSelection);
 
     messenger.log(`Selection Changed in Doc “${document.id}”`);
-    messenger.toast('Selection Changed');
-
-    // if (newSelectionArray.length > 0) {
-    //   const firstSelectedItem = new Crawler({ for: newSelectionArray }).first();
-    //   messenger.log(firstSelectedItem);
-    // }
   }
   return null;
 };

--- a/src/main.js
+++ b/src/main.js
@@ -108,11 +108,6 @@ const onOpenDocument = (context) => {
 
     if (document) {
       messenger.log(`Document “${document.id}” Opened 😻`);
-
-      // need to wait for the UI to be ready
-      setTimeout(() => {
-        messenger.toast(`Document “${document.id}” Opened 😻`);
-      }, 1500);
     }
   }
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,14 +10,14 @@
   "commands": [
     {
       "name": "Dev: Draw Label",
-      "identifier": "draw-label",
+      "identifier": "dev-draw-label",
       "shortcut": "ctrl shift d",
       "script": "./main.js",
       "handler": "drawLabel"
     },
     {
       "name": "Dev: Reset Data",
-      "identifier": "reset-data",
+      "identifier": "dev-reset-data",
       "shortcut": "ctrl shift r",
       "script": "./main.js",
       "handler": "resetData"
@@ -66,8 +66,8 @@
     "items": [
       "label-component",
       "view-gui",
-      "draw-label",
-      "reset-data"
+      "dev-draw-label",
+      "dev-reset-data"
     ]
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Sketch Auto-Spec",
-  "description": "Plugins to label symbols",
+  "name": "Sketch Spec’ing",
+  "description": "Plugin to label symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
   "version": "1.0-b",
@@ -62,7 +62,7 @@
     }
   ],
   "menu": {
-    "title": "Auto-Spec",
+    "title": "Spec’ing",
     "items": [
       "label-component",
       "view-gui",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,14 +11,12 @@
     {
       "name": "Dev: Draw Label",
       "identifier": "dev-draw-label",
-      "shortcut": "ctrl shift d",
       "script": "./main.js",
       "handler": "drawLabel"
     },
     {
       "name": "Dev: Reset Data",
       "identifier": "dev-reset-data",
-      "shortcut": "ctrl shift r",
       "script": "./main.js",
       "handler": "resetData"
     },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -50,7 +50,7 @@
       }
     },
     {
-      "name": "View GUI",
+      "name": "Show Toolbar",
       "identifier": "view-gui",
       "script": "./GUI.js",
       "handlers": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Plugin to label symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
-  "version": "1.0-b004",
+  "version": "1.0-b005",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "compatibleVersion": 3,
   "bundleVersion": 1,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Plugin to label symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
-  "version": "1.0-b",
+  "version": "1.0-b003",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "compatibleVersion": 3,
   "bundleVersion": 1,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Plugin to label symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
-  "version": "1.0-b005",
+  "version": "1.0.0-beta.5",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "compatibleVersion": 3,
   "bundleVersion": 1,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Plugin to label symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
-  "version": "1.0-b003",
+  "version": "1.0-b004",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "compatibleVersion": 3,
   "bundleVersion": 1,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sketch Spec’ing",
+  "name": "Spec’ing",
   "description": "Plugin to label symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",


### PR DESCRIPTION
* Set “Spec’ing” as a working name, for now.
* Better logging for the webview GUI.
* Visually disable the “Measure” button in the GUI toolbar.
* Add an increment-able build number to the versioning for beta releases.