### PR TITLE
Labeling: First Pass

### DIFF
--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -65,6 +65,7 @@ export default class Identifier {
     // parse the connected Lingo Kit data and find the corresponding Kit Symbol
     const kitSymbol = kitSymbols[masterSymbolId];
 
+    // could not find a matching master symbole in the Lingo Kit
     if (!kitSymbol) {
       this.messenger.log(`${masterSymbolId} was not found in a connected Lingo Kit`, 'error');
       this.messenger.toast('😢 This symbol could not be found in a connected Lingo Kit. Please make sure your Kits are up-to-date.');
@@ -76,6 +77,7 @@ export default class Identifier {
     // otherwise, fall back to the kit symbol name
     kitSymbolNameClean = !kitSymbolNameClean ? kitSymbol.name : kitSymbolNameClean;
 
+    // return the official name and log it alongside the original layer name
     this.messenger.log(`Name in Lingo Kit for “${this.layer.name()}” is “${kitSymbolNameClean}”`);
     return kitSymbolNameClean;
   }

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -71,8 +71,13 @@ export default class Identifier {
       return null;
     }
 
-    this.messenger.log(`Name in Lingo Kit for “${this.layer.name()}” is “${kitSymbol.name}”`);
-    return kitSymbol.name;
+    // take only the last segment of the name (after a “/”, if available)
+    let kitSymbolNameClean = kitSymbol.name.split('/').pop();
+    // otherwise, fall back to the kit symbol name
+    kitSymbolNameClean = !kitSymbolNameClean ? kitSymbol.name : kitSymbolNameClean;
+
+    this.messenger.log(`Name in Lingo Kit for “${this.layer.name()}” is “${kitSymbolNameClean}”`);
+    return kitSymbolNameClean;
   }
 
   /**

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -1,4 +1,9 @@
-import { Rectangle, ShapePath, Text } from 'sketch/dom';
+import {
+  Group,
+  Rectangle,
+  ShapePath,
+  Text,
+} from 'sketch/dom';
 
 /**
  * @description A class to add elements to the Sketch file.
@@ -29,15 +34,15 @@ export default class Painter {
 
     // x, y placement of the label on the artboard
     const placement = {
-      x: 20,
-      y: 20,
+      x: 30,
+      y: 30,
     };
 
     // build the text box
     const text = new Text({
       frame: {
-        x: placement.x + 16,
-        y: placement.y + 3,
+        x: 16,
+        y: 3,
       },
       parent: this.artboard,
       text: layerLabel,
@@ -58,8 +63,7 @@ export default class Painter {
 
     // build the rounded rectangle
     const rectangle = new ShapePath({
-      frame: new Rectangle(placement.x, placement.y, 200, 30),
-      name: layerName,
+      frame: new Rectangle(0, 0, 200, 30),
       parent: this.artboard,
       style: {
         borders: [{
@@ -79,8 +83,8 @@ export default class Painter {
 
     // build the dangling diamond
     const diamond = new ShapePath({
-      frame: new Rectangle(placement.x, placement.y + 27, 6, 6),
-      name: `${layerName} diamond`,
+      frame: new Rectangle(0, 27, 6, 6),
+      name: 'Diamond',
       parent: this.artboard,
       style: {
         borders: [{
@@ -101,12 +105,32 @@ export default class Painter {
 
     // move the diamond to the mid-point of the rectangle
     const diamondMidX = ((rectangleWidth - 8) / 2);
-    diamond.frame.x = diamondMidX + placement.x;
+    diamond.frame.x = diamondMidX;
 
     // set z-axis placement of all elements
     rectangle.moveToFront();
     text.index = rectangle.index + 1;
     diamond.index = rectangle.index - 1;
+
+    const group = new Group({
+      frame: {
+        x: placement.x,
+        y: placement.y,
+      },
+      name: layerName,
+      parent: this.artboard,
+    });
+
+    group.frame.width = rectangle.frame.width;
+    group.frame.height = rectangle.frame.height + 4;
+
+    rectangle.parent = group;
+    diamond.parent = group;
+    text.parent = group;
+
+    // move the group
+    group.frame.x = placement.x;
+    group.frame.y = placement.y;
 
     return null;
   }

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -94,7 +94,7 @@ export default class Painter {
     new ShapePath({ // eslint-disable-line no-new
       frame: new Rectangle(0, 0, 1, 1),
       locked: true,
-      name: '--- placeholder',
+      name: '--- keystone - please DO NOT delete me 🤗',
       parent: newContainerGroup,
     });
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -1,3 +1,4 @@
+import { fromNative } from 'sketch';
 import {
   Group,
   Rectangle,
@@ -13,11 +14,12 @@ import {
  *
  * @constructor
  *
- * @property artboard The artboard in the Sketch file that we want to modify.
+ * @property layer The layer in the Sketch file that we want to label or modify.
  */
 export default class Painter {
-  constructor({ for: artboard }) {
-    this.artboard = artboard;
+  constructor({ for: layer }) {
+    this.layer = layer;
+    this.artboard = this.layer.parentArtboard();
   }
 
   /**
@@ -30,7 +32,8 @@ export default class Painter {
    * @returns {Object} A Sketch ShapePath Rectangle object.
    */
   addLabel(layerLabel = 'New Label') {
-    const layerName = `Label for ${layerLabel}`;
+    const layerName = this.layer.name();
+    const groupName = `Label for ${layerName}`;
 
     // x, y placement of the label on the artboard
     const placement = {
@@ -117,7 +120,7 @@ export default class Painter {
         x: placement.x,
         y: placement.y,
       },
-      name: layerName,
+      name: groupName,
       parent: this.artboard,
     });
 
@@ -129,6 +132,8 @@ export default class Painter {
     text.parent = group;
 
     // move the group
+    const originalLayerIndex = fromNative(this.layer).index;
+    group.index = originalLayerIndex + 1;
     group.frame.x = placement.x;
     group.frame.y = placement.y;
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -148,6 +148,21 @@ export default class Painter {
    * @returns {Object} A Sketch ShapePath Rectangle object.
    */
   addLabel(layerLabel = 'New Label') {
+    const result = {
+      success: false,
+      error: false,
+      messages: {
+        toast: null,
+        log: null,
+      },
+    };
+
+    if (!this.artboard) {
+      result.error = true;
+      result.messages.log = 'Selection not on artboard';
+      result.messages.toast = 'Your selection needs to be on an artboard';
+      return result;
+    }
     const layerName = this.layer.name();
     const layerId = fromNative(this.layer).id;
     const groupName = `Label for ${layerName}`;
@@ -320,6 +335,7 @@ export default class Painter {
 
     updateSettings('labeledLayers', newSettingsEntry);
 
-    return null;
+    result.success = true;
+    return result;
   }
 }

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -7,9 +7,20 @@ import {
 } from 'sketch/dom';
 import { PLUGIN_IDENTIFIER } from './Tools';
 
+// --- settings/state management
+// good candidate to move this to its own class once it gets re-used
 const initialSettingsState = {
   containerGroups: [],
   labeledLayers: [],
+};
+
+const initialResultState = {
+  success: false,
+  error: false,
+  messages: {
+    toast: null,
+    log: null,
+  },
 };
 
 const updateSettings = (key, data, action = 'add') => {
@@ -41,10 +52,11 @@ const updateSettings = (key, data, action = 'add') => {
   }
 
   Settings.setSettingForKey(PLUGIN_IDENTIFIER, settings);
-  // log(Settings.settingForKey(PLUGIN_IDENTIFIER));
   return settings;
 };
 
+// --- find layer by ID in array of layers
+// should move this to Crawler
 const findLayerById = (layers, layerId) => {
   if (!layers || !layerId) {
     return null;
@@ -61,6 +73,234 @@ const findLayerById = (layers, layerId) => {
   return foundLayer;
 };
 
+// --- some private functions for drawing/positioning label elements in the Sketch file
+const buildLabelElements = (artboard, layerLabel) => {
+  // build the text box
+  const text = new Text({
+    frame: {
+      x: 16,
+      y: 3,
+    },
+    parent: artboard,
+    text: layerLabel,
+    style: {
+      alignment: Text.Alignment.left,
+      borders: [{
+        enabled: false,
+      }],
+      fontFamily: 'helevetica neue',
+      fontSize: 12,
+      fontWeight: 4,
+      kerning: 0,
+      lineHeight: 22,
+      textColor: '#ffffffff',
+    },
+  });
+  text.adjustToFit();
+
+  // build the rounded rectangle
+  const rectangle = new ShapePath({
+    frame: new Rectangle(0, 0, 200, 30),
+    parent: artboard,
+    style: {
+      borders: [{
+        enabled: false,
+        thickness: 0,
+      }],
+      fills: ['#027affff'],
+    },
+  });
+
+  // set rounded corners of the rectangle
+  const { points } = rectangle;
+  points.forEach((point) => {
+    point.cornerRadius = 2; // eslint-disable-line no-param-reassign
+    return null;
+  });
+
+  // build the dangling diamond
+  const diamond = new ShapePath({
+    frame: new Rectangle(0, 27, 6, 6),
+    name: 'Diamond',
+    parent: artboard,
+    style: {
+      borders: [{
+        enabled: false,
+        thickness: 0,
+      }],
+      fills: ['#027affff'],
+    },
+    transform: {
+      rotation: 45,
+    },
+  });
+
+  // set rectangle width based on text width
+  const textWidth = text.frame.width;
+  const rectangleWidth = textWidth + 32;
+  rectangle.frame.width = rectangleWidth;
+
+  // move the diamond to the mid-point of the rectangle
+  const diamondMidX = ((rectangleWidth - 8) / 2);
+  diamond.frame.x = diamondMidX;
+
+  // set z-axis placement of all elements
+  rectangle.moveToFront();
+  text.index = rectangle.index + 1;
+  diamond.index = rectangle.index - 1;
+
+  return {
+    diamond,
+    rectangle,
+    text,
+  };
+};
+
+const positionLabelElements = (containerGroup, groupName, labelElements, layerFrame) => {
+  const {
+    diamond,
+    rectangle,
+    text,
+  } = labelElements;
+
+  const { artboardWidth } = layerFrame;
+  const layerWidth = layerFrame.width;
+  const layerX = layerFrame.x;
+  const layerY = layerFrame.y;
+  const originalLayerIndex = layerFrame.index;
+
+  // create the label group
+  const group = new Group({
+    name: groupName,
+    parent: containerGroup,
+  });
+
+  // size the label group frame
+  group.frame.width = rectangle.frame.width;
+  group.frame.height = rectangle.frame.height + 4;
+
+  // add elements to the group
+  rectangle.parent = group;
+  diamond.parent = group;
+  text.parent = group;
+
+  // position the group within the artboard, above the layer receiving the label
+  let diamondAdjustment = null;
+
+  // move group to z-index right above layer to label
+  group.index = originalLayerIndex + 1;
+
+  // initial placement based on layer to label
+  let placementX = (
+    layerX + (
+      (layerWidth - group.frame.width) / 2
+    )
+  );
+  let placementY = layerY - 38;
+
+  // correct for left bleed
+  if (placementX < 0) {
+    placementX = 5;
+    diamondAdjustment = 'left';
+  }
+
+  // correct for right bleed
+  if ((placementX + group.frame.width) > artboardWidth) {
+    placementX = artboardWidth - group.frame.width - 5;
+    diamondAdjustment = 'right';
+  }
+
+  // correct for top bleed
+  if (placementY < 0) {
+    placementY = 5;
+  }
+
+  // set label group placement
+  group.frame.x = placementX;
+  group.frame.y = placementY;
+
+  // adjust diamond, if necessary
+  if (diamondAdjustment) {
+    // move the diamond to the mid-point of the layer to label
+    let diamondLayerMidX = null;
+    switch (diamondAdjustment) {
+      case 'left':
+        diamondLayerMidX = ((layerX + layerWidth - 8) / 2);
+        break;
+      case 'right':
+        diamondLayerMidX = ((layerX - group.frame.x) + ((layerWidth - 8) / 2));
+        break;
+      default:
+        diamondLayerMidX = 0;
+    }
+    diamond.frame.x = diamondLayerMidX;
+  }
+
+  return group;
+};
+
+const createContainerGroup = (artboard) => {
+  const artboardId = fromNative(artboard).id;
+  const newContainerGroup = new Group({
+    frame: {
+      x: 0,
+      y: 0,
+      width: artboard.frame().width(),
+      height: artboard.frame().height(),
+    },
+    locked: true,
+    name: '+++ Auto-Spec Labels +++',
+    parent: artboard,
+  });
+
+  // add placeholder rectangle to keep everything relative to 0, 0 on the artboard
+  new ShapePath({ // eslint-disable-line no-new
+    frame: new Rectangle(0, 0, 1, 1),
+    locked: true,
+    name: '--- keystone - please DO NOT delete me 🤗',
+    parent: newContainerGroup,
+  });
+
+  const newContainerGroupSetting = {
+    artboardId,
+    id: newContainerGroup.id,
+  };
+
+  updateSettings('containerGroups', newContainerGroupSetting);
+
+  return newContainerGroup;
+};
+
+const setContainerGroup = (artboard) => {
+  const settings = Settings.settingForKey(PLUGIN_IDENTIFIER);
+  const artboardId = fromNative(artboard).id;
+  let containerGroup = null;
+  let containerGroupId = null;
+
+  if (settings && settings.containerGroups) {
+    settings.containerGroups.forEach((containerGroupLookupPair) => {
+      if (containerGroupLookupPair.artboardId === artboardId) {
+        containerGroupId = containerGroupLookupPair.id;
+      }
+      return null;
+    });
+    containerGroup = findLayerById(artboard.layers(), containerGroupId);
+  }
+
+  if (!containerGroup) {
+    if (containerGroupId) {
+      updateSettings('containerGroups', { id: containerGroupId }, 'remove');
+    }
+    containerGroup = createContainerGroup(artboard);
+  }
+
+  // move to the front
+  fromNative(containerGroup).moveToFront();
+
+  return containerGroup;
+};
+
+// --- main Painter class function
 /**
  * @description A class to add elements to the Sketch file.
  *
@@ -77,65 +317,14 @@ export default class Painter {
     this.artboard = this.layer.parentArtboard();
   }
 
-  createContainerGroup(artboardId) {
-    const newContainerGroup = new Group({
-      frame: {
-        x: 0,
-        y: 0,
-        width: this.artboard.frame().width(),
-        height: this.artboard.frame().height(),
-      },
-      locked: true,
-      name: '+++ Auto-Spec Labels +++',
-      parent: this.artboard,
-    });
-
-    // add placeholder rectangle to keep everything relative to 0, 0 on the artboard
-    new ShapePath({ // eslint-disable-line no-new
-      frame: new Rectangle(0, 0, 1, 1),
-      locked: true,
-      name: '--- keystone - please DO NOT delete me 🤗',
-      parent: newContainerGroup,
-    });
-
-    const newContainerGroupSetting = {
-      artboardId,
-      id: newContainerGroup.id,
-    };
-
-    updateSettings('containerGroups', newContainerGroupSetting);
-
-    return newContainerGroup;
-  }
-
-  setContainerGroup() {
-    const settings = Settings.settingForKey(PLUGIN_IDENTIFIER);
-    const artboardId = fromNative(this.artboard).id;
-    let containerGroup = null;
-    let containerGroupId = null;
-
-    if (settings && settings.containerGroups) {
-      settings.containerGroups.forEach((containerGroupLookupPair) => {
-        if (containerGroupLookupPair.artboardId === artboardId) {
-          containerGroupId = containerGroupLookupPair.id;
-        }
-        return null;
-      });
-      containerGroup = findLayerById(this.artboard.layers(), containerGroupId);
-      // Settings.setSettingForKey(PLUGIN_IDENTIFIER, null);
-    }
-
-    if (!containerGroup) {
-      if (containerGroupId) {
-        updateSettings('containerGroups', { id: containerGroupId }, 'remove');
+  removeLabel(existingItem) {
+    const layerContainer = findLayerById(this.artboard.layers(), existingItem.containerGroupId);
+    if (layerContainer) {
+      const layerToDelete = findLayerById(layerContainer.layers(), existingItem.id);
+      if (layerToDelete) {
+        fromNative(layerToDelete).remove(); // .remove() only works on a js object, not obj-c
       }
-      containerGroup = this.createContainerGroup(artboardId);
     }
-
-    // move to the front
-    fromNative(containerGroup).moveToFront();
-
-    return containerGroup;
   }
 
   /**
@@ -148,193 +337,61 @@ export default class Painter {
    * @returns {Object} A Sketch ShapePath Rectangle object.
    */
   addLabel(layerLabel = 'New Label') {
-    const result = {
-      success: false,
-      error: false,
-      messages: {
-        toast: null,
-        log: null,
-      },
-    };
+    const result = initialResultState;
 
+    // return an error if the selection is not placed on an artboard
     if (!this.artboard) {
       result.error = true;
       result.messages.log = 'Selection not on artboard';
       result.messages.toast = 'Your selection needs to be on an artboard';
       return result;
     }
+
+    // set up some information
     const layerName = this.layer.name();
     const layerId = fromNative(this.layer).id;
     const groupName = `Label for ${layerName}`;
-    const containerGroup = this.setContainerGroup();
-
-    // check if we have already labeled this one and remove it
     const settings = Settings.settingForKey(PLUGIN_IDENTIFIER);
+
+    // create or locate the container group
+    const containerGroup = setContainerGroup(this.artboard);
+
+    // check if we have already labeled this element and remove the old label
     if (settings && settings.labeledLayers) {
       const existingItem = settings.labeledLayers.find(
         foundItem => (foundItem.originalId === layerId),
       );
+
+      // remove old label layer + remove from data
       if (existingItem) {
         updateSettings('labeledLayers', { id: existingItem.id }, 'remove');
-        const layerContainer = findLayerById(this.artboard.layers(), existingItem.containerGroupId);
-        if (layerContainer) {
-          const layerToDelete = findLayerById(layerContainer.layers(), existingItem.id);
-          if (layerToDelete) {
-            fromNative(layerToDelete).remove(); // .remove() only works on a js object, not obj-c
-          }
-        }
+        this.removeLabel(existingItem);
       }
     }
 
-    // build the text box
-    const text = new Text({
-      frame: {
-        x: 16,
-        y: 3,
-      },
-      parent: this.artboard,
-      text: layerLabel,
-      style: {
-        alignment: Text.Alignment.left,
-        borders: [{
-          enabled: false,
-        }],
-        fontFamily: 'helevetica neue',
-        fontSize: 12,
-        fontWeight: 4,
-        kerning: 0,
-        lineHeight: 22,
-        textColor: '#ffffffff',
-      },
-    });
-    text.adjustToFit();
+    // construct the base label elements
+    const labelElements = buildLabelElements(this.artboard, layerLabel);
 
-    // build the rounded rectangle
-    const rectangle = new ShapePath({
-      frame: new Rectangle(0, 0, 200, 30),
-      parent: this.artboard,
-      style: {
-        borders: [{
-          enabled: false,
-          thickness: 0,
-        }],
-        fills: ['#027affff'],
-      },
-    });
+    // group and position the base label elements
+    const layerFrame = {
+      artboardWidth: this.artboard.frame().width(),
+      width: this.layer.frame().width(),
+      height: this.layer.frame().height(),
+      x: this.layer.frame().x(),
+      y: this.layer.frame().y(),
+      index: fromNative(this.layer).index,
+    };
+    const group = positionLabelElements(containerGroup, groupName, labelElements, layerFrame);
 
-    // set rounded corners of the rectangle
-    const { points } = rectangle;
-    points.forEach((point) => {
-      point.cornerRadius = 2; // eslint-disable-line no-param-reassign
-      return null;
-    });
-
-    // build the dangling diamond
-    const diamond = new ShapePath({
-      frame: new Rectangle(0, 27, 6, 6),
-      name: 'Diamond',
-      parent: this.artboard,
-      style: {
-        borders: [{
-          enabled: false,
-          thickness: 0,
-        }],
-        fills: ['#027affff'],
-      },
-      transform: {
-        rotation: 45,
-      },
-    });
-
-    // set rectangle width based on text width
-    const textWidth = text.frame.width;
-    const rectangleWidth = textWidth + 32;
-    rectangle.frame.width = rectangleWidth;
-
-    // move the diamond to the mid-point of the rectangle
-    const diamondMidX = ((rectangleWidth - 8) / 2);
-    diamond.frame.x = diamondMidX;
-
-    // set z-axis placement of all elements
-    rectangle.moveToFront();
-    text.index = rectangle.index + 1;
-    diamond.index = rectangle.index - 1;
-
-    const group = new Group({
-      name: groupName,
-      parent: containerGroup,
-    });
-
-    group.frame.width = rectangle.frame.width;
-    group.frame.height = rectangle.frame.height + 4;
-
-    rectangle.parent = group;
-    diamond.parent = group;
-    text.parent = group;
-
-    // position the group
-    const artboardWidth = this.artboard.frame().width();
-    const layerWidth = this.layer.frame().width();
-    const originalLayerIndex = fromNative(this.layer).index;
-    let diamondAdjustment = null;
-
-    // move group to index right above layer to label
-    group.index = originalLayerIndex + 1;
-
-    // initial placement based on layer to label
-    let placementX = (
-      this.layer.frame().x() + (
-        (layerWidth - group.frame.width) / 2
-      )
-    );
-    let placementY = this.layer.frame().y() - 38;
-
-    // correct for left bleed
-    if (placementX < 0) {
-      placementX = 5;
-      diamondAdjustment = 'left';
-    }
-
-    // correct for right bleed
-    if ((placementX + group.frame.width) > artboardWidth) {
-      placementX = artboardWidth - group.frame.width - 5;
-      diamondAdjustment = 'right';
-    }
-
-    // correct for top bleed
-    if (placementY < 0) {
-      placementY = 5;
-    }
-
-    // set label group placement
-    group.frame.x = placementX;
-    group.frame.y = placementY;
-
-    // adjust diamond, if necessary
-    if (diamondAdjustment) {
-      // move the diamond to the mid-point of the layer to label
-      let diamondLayerMidX = null;
-      switch (diamondAdjustment) {
-        case 'left':
-          diamondLayerMidX = ((this.layer.frame().x() + layerWidth - 8) / 2);
-          break;
-        case 'right':
-          diamondLayerMidX = ((this.layer.frame().x() - group.frame.x) + ((layerWidth - 8) / 2));
-          break;
-        default:
-          diamondLayerMidX = 0;
-      }
-      diamond.frame.x = diamondLayerMidX;
-    }
-
+    // update data (connect new label with layer receiving label)
     const newSettingsEntry = {
       containerGroupId: fromNative(containerGroup).id,
       id: group.id,
       originalId: layerId,
     };
-
     updateSettings('labeledLayers', newSettingsEntry);
 
+    // return a successful result
     result.success = true;
     return result;
   }

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -124,6 +124,9 @@ export default class Painter {
       containerGroup = this.createContainerGroup(artboardId);
     }
 
+    // move to the front
+    fromNative(containerGroup).moveToFront();
+
     return containerGroup;
   }
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -5,7 +5,7 @@ import {
   ShapePath,
   Text,
 } from 'sketch/dom';
-import { PLUGIN_IDENTIFIER } from './Tools';
+import { findLayerById, PLUGIN_IDENTIFIER } from './Tools';
 
 // --- settings/state management
 // good candidate to move this to its own class once it gets re-used
@@ -55,25 +55,7 @@ const updateSettings = (key, data, action = 'add') => {
   return settings;
 };
 
-// --- find layer by ID in array of layers
-// should move this to Crawler
-const findLayerById = (layers, layerId) => {
-  if (!layers || !layerId) {
-    return null;
-  }
-
-  let foundLayer = null;
-  layers.forEach((layer) => {
-    const layerJSON = fromNative(layer);
-    if (layerJSON.id === layerId) {
-      foundLayer = layer;
-    }
-    return foundLayer;
-  });
-  return foundLayer;
-};
-
-// --- some private functions for drawing/positioning label elements in the Sketch file
+// --- private functions for drawing/positioning label elements in the Sketch file
 const buildLabelElements = (artboard, layerLabel) => {
   // build the text box
   const text = new Text({

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -27,10 +27,17 @@ export default class Painter {
   addLabel(layerLabel = 'New Label') {
     const layerName = `Label for ${layerLabel}`;
 
+    // x, y placement of the label on the artboard
+    const placement = {
+      x: 20,
+      y: 20,
+    };
+
+    // build the text box
     const text = new Text({
       frame: {
-        x: 12,
-        y: 12,
+        x: placement.x + 16,
+        y: placement.y + 3,
       },
       parent: this.artboard,
       text: layerLabel,
@@ -49,8 +56,9 @@ export default class Painter {
     });
     text.adjustToFit();
 
+    // build the rounded rectangle
     const rectangle = new ShapePath({
-      frame: new Rectangle(10, 10, 200, 30),
+      frame: new Rectangle(placement.x, placement.y, 200, 30),
       name: layerName,
       parent: this.artboard,
       style: {
@@ -62,8 +70,16 @@ export default class Painter {
       },
     });
 
+    // set rounded corners of the rectangle
+    const { points } = rectangle;
+    points.forEach((point) => {
+      point.cornerRadius = 2; // eslint-disable-line no-param-reassign
+      return null;
+    });
+
+    // build the dangling diamond
     const diamond = new ShapePath({
-      frame: new Rectangle(5, 5, 6, 6),
+      frame: new Rectangle(placement.x, placement.y + 27, 6, 6),
       name: `${layerName} diamond`,
       parent: this.artboard,
       style: {
@@ -78,10 +94,19 @@ export default class Painter {
       },
     });
 
+    // set rectangle width based on text width
+    const textWidth = text.frame.width;
+    const rectangleWidth = textWidth + 32;
+    rectangle.frame.width = rectangleWidth;
+
+    // move the diamond to the mid-point of the rectangle
+    const diamondMidX = ((rectangleWidth - 8) / 2);
+    diamond.frame.x = diamondMidX + placement.x;
+
+    // set z-axis placement of all elements
     rectangle.moveToFront();
     text.index = rectangle.index + 1;
     diamond.index = rectangle.index - 1;
-    // log(text);
 
     return null;
   }

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -136,17 +136,17 @@ export default class Painter {
 
     // correct for left bleed
     if (placementX < 0) {
-      placementX = 0;
+      placementX = 5;
     }
 
     // correct for right bleed
     if ((placementX + group.frame.width) > artboardWidth) {
-      placementX = artboardWidth - group.frame.width;
+      placementX = artboardWidth - group.frame.width - 5;
     }
 
     // correct for top bleed
     if (placementY < 0) {
-      placementY = 0;
+      placementY = 5;
     }
 
     // set placement

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -36,27 +36,51 @@ export default class Painter {
       text: layerLabel,
       style: {
         alignment: Text.Alignment.left,
-        fontFamily: 'system',
-        fontSize: 18,
-        fontWeight: 6,
+        borders: [{
+          enabled: false,
+        }],
+        fontFamily: 'helevetica neue',
+        fontSize: 12,
+        fontWeight: 4,
         kerning: 0,
         lineHeight: 22,
-        textColor: '#000000ff',
+        textColor: '#ffffffff',
       },
     });
     text.adjustToFit();
 
-    const shape = new ShapePath({
-      frame: new Rectangle(10, 10, 60, 60),
+    const rectangle = new ShapePath({
+      frame: new Rectangle(10, 10, 200, 30),
       name: layerName,
       parent: this.artboard,
       style: {
-        fills: ['#ffcc3399'],
+        borders: [{
+          enabled: false,
+          thickness: 0,
+        }],
+        fills: ['#027affff'],
       },
     });
 
-    shape.moveToFront();
-    text.index = shape.index + 1;
+    const diamond = new ShapePath({
+      frame: new Rectangle(5, 5, 6, 6),
+      name: `${layerName} diamond`,
+      parent: this.artboard,
+      style: {
+        borders: [{
+          enabled: false,
+          thickness: 0,
+        }],
+        fills: ['#027affff'],
+      },
+      transform: {
+        rotation: 45,
+      },
+    });
+
+    rectangle.moveToFront();
+    text.index = rectangle.index + 1;
+    diamond.index = rectangle.index - 1;
     // log(text);
 
     return null;

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -121,27 +121,33 @@ export default class Painter {
     diamond.parent = group;
     text.parent = group;
 
-    // move the group
-    // initial placement based on layer to label
+    // position the group
     const artboardWidth = this.artboard.frame().width();
+    const layerWidth = this.layer.frame().width();
+    const originalLayerIndex = fromNative(this.layer).index;
+    let diamondAdjustment = null;
+
+    // move group to index right above layer to label
+    group.index = originalLayerIndex + 1;
+
+    // initial placement based on layer to label
     let placementX = (
       this.layer.frame().x() + (
-        (this.layer.frame().width() - group.frame.width) / 2
+        (layerWidth - group.frame.width) / 2
       )
     );
     let placementY = this.layer.frame().y() - 38;
 
-    const originalLayerIndex = fromNative(this.layer).index;
-    group.index = originalLayerIndex + 1;
-
     // correct for left bleed
     if (placementX < 0) {
       placementX = 5;
+      diamondAdjustment = 'left';
     }
 
     // correct for right bleed
     if ((placementX + group.frame.width) > artboardWidth) {
       placementX = artboardWidth - group.frame.width - 5;
+      diamondAdjustment = 'right';
     }
 
     // correct for top bleed
@@ -149,9 +155,26 @@ export default class Painter {
       placementY = 5;
     }
 
-    // set placement
+    // set label group placement
     group.frame.x = placementX;
     group.frame.y = placementY;
+
+    // adjust diamond, if necessary
+    if (diamondAdjustment) {
+      // move the diamond to the mid-point of the layer to label
+      let diamondLayerMidX = null;
+      switch (diamondAdjustment) {
+        case 'left':
+          diamondLayerMidX = ((this.layer.frame().x() + layerWidth - 8) / 2);
+          break;
+        case 'right':
+          diamondLayerMidX = ((this.layer.frame().x() - group.frame.x) + ((layerWidth - 8) / 2));
+          break;
+        default:
+          diamondLayerMidX = 0;
+      }
+      diamond.frame.x = diamondLayerMidX;
+    }
 
     return null;
   }

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -82,9 +82,10 @@ export default class Painter {
       frame: {
         x: 0,
         y: 0,
-        width: 1,
-        height: 1,
+        width: this.artboard.frame().width(),
+        height: this.artboard.frame().height(),
       },
+      locked: true,
       name: '+++ Auto-Spec Labels +++',
       parent: this.artboard,
     });

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -35,12 +35,6 @@ export default class Painter {
     const layerName = this.layer.name();
     const groupName = `Label for ${layerName}`;
 
-    // x, y placement of the label on the artboard
-    const placement = {
-      x: 30,
-      y: 30,
-    };
-
     // build the text box
     const text = new Text({
       frame: {
@@ -116,10 +110,6 @@ export default class Painter {
     diamond.index = rectangle.index - 1;
 
     const group = new Group({
-      frame: {
-        x: placement.x,
-        y: placement.y,
-      },
       name: groupName,
       parent: this.artboard,
     });
@@ -132,10 +122,18 @@ export default class Painter {
     text.parent = group;
 
     // move the group
+    // x, y placement of the label on the artboard
+    const placementX = (
+      this.layer.frame().x() + (
+        (this.layer.frame().width() - group.frame.width) / 2
+      )
+    );
+    const placementY = this.layer.frame().y() - 38;
+
     const originalLayerIndex = fromNative(this.layer).index;
     group.index = originalLayerIndex + 1;
-    group.frame.x = placement.x;
-    group.frame.y = placement.y;
+    group.frame.x = placementX;
+    group.frame.y = placementY;
 
     return null;
   }

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -90,6 +90,14 @@ export default class Painter {
       parent: this.artboard,
     });
 
+    // add placeholder rectangle to keep everything relative to 0, 0 on the artboard
+    new ShapePath({ // eslint-disable-line no-new
+      frame: new Rectangle(0, 0, 1, 1),
+      locked: true,
+      name: '--- placeholder',
+      parent: newContainerGroup,
+    });
+
     const newContainerGroupSetting = {
       artboardId,
       id: newContainerGroup.id,

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -122,16 +122,34 @@ export default class Painter {
     text.parent = group;
 
     // move the group
-    // x, y placement of the label on the artboard
-    const placementX = (
+    // initial placement based on layer to label
+    const artboardWidth = this.artboard.frame().width();
+    let placementX = (
       this.layer.frame().x() + (
         (this.layer.frame().width() - group.frame.width) / 2
       )
     );
-    const placementY = this.layer.frame().y() - 38;
+    let placementY = this.layer.frame().y() - 38;
 
     const originalLayerIndex = fromNative(this.layer).index;
     group.index = originalLayerIndex + 1;
+
+    // correct for left bleed
+    if (placementX < 0) {
+      placementX = 0;
+    }
+
+    // correct for right bleed
+    if ((placementX + group.frame.width) > artboardWidth) {
+      placementX = artboardWidth - group.frame.width;
+    }
+
+    // correct for top bleed
+    if (placementY < 0) {
+      placementY = 0;
+    }
+
+    // set placement
     group.frame.x = placementX;
     group.frame.y = placementY;
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -5,7 +5,8 @@ import {
   ShapePath,
   Text,
 } from 'sketch/dom';
-import { findLayerById, PLUGIN_IDENTIFIER } from './Tools';
+import { findLayerById } from './Tools';
+import { PLUGIN_IDENTIFIER } from './constants';
 
 // --- settings/state management
 // good candidate to move this to its own class once it gets re-used

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -1,5 +1,14 @@
 import { toArray } from 'util';
 
+/**
+ * @description A constant with unique string to identify the plugin within Sketch.
+ * Changing this will potentially break data retrieval in Sketch files that used
+ * earlier versions of the plugin with a different identifier.
+ *
+ * @kind constant
+ * @name options
+ * @type {string}
+ */
 const PLUGIN_IDENTIFIER = 'com.linkedinlabs.sketch.auto-spec-plugin';
 
 /**

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -1,18 +1,6 @@
 import { toArray } from 'util';
 import { fromNative } from 'sketch';
 
-// --- contants
-/**
- * @description A constant with unique string to identify the plugin within Sketch.
- * Changing this will potentially break data retrieval in Sketch files that used
- * earlier versions of the plugin with a different identifier.
- *
- * @kind constant
- * @name options
- * @type {string}
- */
-const PLUGIN_IDENTIFIER = 'com.linkedinlabs.sketch.auto-spec-plugin';
-
 // --- helper functions
 /**
  * @description Takes context (if made available) and returns the document
@@ -67,7 +55,7 @@ const setArray = nsArray => toArray(nsArray);
  * @name findLayerById
  * @param {Array} layers Array of layers to search through.
  * @param {string} layerId The string ID of the layer to find.
- * @returns {Object} foundLayer The layer that was found (or null).
+ * @returns {Object} The layer that was found (or null).
  */
 const findLayerById = (layers, layerId) => {
   if (!layers || !layerId) {
@@ -89,6 +77,5 @@ export {
   findLayerById,
   getDocument,
   getSelection,
-  PLUGIN_IDENTIFIER,
   setArray,
 };

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -1,5 +1,7 @@
 import { toArray } from 'util';
+import { fromNative } from 'sketch';
 
+// --- contants
 /**
  * @description A constant with unique string to identify the plugin within Sketch.
  * Changing this will potentially break data retrieval in Sketch files that used
@@ -11,6 +13,7 @@ import { toArray } from 'util';
  */
 const PLUGIN_IDENTIFIER = 'com.linkedinlabs.sketch.auto-spec-plugin';
 
+// --- helper functions
 /**
  * @description Takes context (if made available) and returns the document
  * or derives the `currentDocument` from `NSDocumentController` (necessary
@@ -54,11 +57,36 @@ const getSelection = objcDocument => objcDocument.selectedLayers().layers() || n
  * @name setArray
  * @param {Array} nsArray The NSArray-formatted array.
  * @returns {Array} Javascript Array.
- * @private
  */
 const setArray = nsArray => toArray(nsArray);
 
+/**
+ * @description Find a layer by ID in an array of layers.
+ *
+ * @kind function
+ * @name findLayerById
+ * @param {Array} layers Array of layers to search through.
+ * @param {string} layerId The string ID of the layer to find.
+ * @returns {Object} foundLayer The layer that was found (or null).
+ */
+const findLayerById = (layers, layerId) => {
+  if (!layers || !layerId) {
+    return null;
+  }
+
+  let foundLayer = null;
+  layers.forEach((layer) => {
+    const layerJSON = fromNative(layer);
+    if (layerJSON.id === layerId) {
+      foundLayer = layer;
+    }
+    return foundLayer;
+  });
+  return foundLayer;
+};
+
 export {
+  findLayerById,
   getDocument,
   getSelection,
   PLUGIN_IDENTIFIER,

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -1,5 +1,7 @@
 import { toArray } from 'util';
 
+const PLUGIN_IDENTIFIER = 'com.linkedinlabs.sketch.auto-spec-plugin';
+
 /**
  * @description Takes context (if made available) and returns the document
  * or derives the `currentDocument` from `NSDocumentController` (necessary
@@ -50,5 +52,6 @@ const setArray = nsArray => toArray(nsArray);
 export {
   getDocument,
   getSelection,
+  PLUGIN_IDENTIFIER,
   setArray,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * @description A constant with unique string to identify the plugin within Sketch.
+ * Changing this will potentially break data retrieval in Sketch files that used
+ * earlier versions of the plugin with a different identifier.
+ *
+ * @kind constant
+ * @name options
+ * @type {string}
+ */
+const PLUGIN_IDENTIFIER = 'com.linkedinlabs.sketch.auto-spec-plugin';
+
+export { PLUGIN_IDENTIFIER };
+/* eslint-enable import/prefer-default-export */

--- a/src/main.js
+++ b/src/main.js
@@ -87,8 +87,16 @@ const labelLayer = (context = null) => {
   const kitLayerLabel = layerToLabel.label();
 
   // draw the label
+  let paintResult = null;
   if (kitLayerLabel) {
-    painter.addLabel(kitLayerLabel);
+    paintResult = painter.addLabel(kitLayerLabel);
+  }
+
+  if (paintResult && (paintResult.error || !paintResult.success)) {
+    const toastMessage = paintResult.error && paintResult.messages.toast ? paintResult.messages.toast : 'An error occured';
+    const logMessage = paintResult.error && paintResult.messages.log ? paintResult.messages.log : 'An error occured';
+    messenger.log(logMessage, 'error');
+    return messenger.toast(toastMessage);
   }
   return null;
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,10 @@
-import { fromNative } from 'sketch';
+import { fromNative, Settings } from 'sketch';
 
 import Crawler from './Crawler';
 import Painter from './Painter';
 import Identifier from './Identifier';
 import Messenger from './Messenger';
-import { getDocument, getSelection } from './Tools';
+import { getDocument, getSelection, PLUGIN_IDENTIFIER } from './Tools';
 
 /**
  * @description A shared helper function to set up in-UI messages and the logger.
@@ -44,6 +44,17 @@ const drawLabel = (context) => {
 
   const painter = new Painter({ for: selection[0] });
   painter.addLabel('Hello, I am Component');
+  return null;
+};
+
+/**
+ * @description Temporary dev function to remove data in the `PLUGIN_IDENTIFIER` namespace.
+ *
+ * @kind function
+ * @name resetData
+ */
+const resetData = () => {
+  Settings.setSettingForKey(PLUGIN_IDENTIFIER, null);
   return null;
 };
 
@@ -135,4 +146,5 @@ export {
   labelLayer,
   onOpenDocument,
   onSelectionChange,
+  resetData,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -4,11 +4,8 @@ import Crawler from './Crawler';
 import Painter from './Painter';
 import Identifier from './Identifier';
 import Messenger from './Messenger';
-import {
-  getDocument,
-  getSelection,
-  PLUGIN_IDENTIFIER,
-} from './Tools';
+import { getDocument, getSelection } from './Tools';
+import { PLUGIN_IDENTIFIER } from './constants';
 
 /**
  * @description A shared helper function to set up in-UI messages and the logger.

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,11 @@ import Crawler from './Crawler';
 import Painter from './Painter';
 import Identifier from './Identifier';
 import Messenger from './Messenger';
-import { getDocument, getSelection, PLUGIN_IDENTIFIER } from './Tools';
+import {
+  getDocument,
+  getSelection,
+  PLUGIN_IDENTIFIER,
+} from './Tools';
 
 /**
  * @description A shared helper function to set up in-UI messages and the logger.
@@ -73,10 +77,12 @@ const labelLayer = (context = null) => {
     selection,
   } = assemble(context);
 
+  // need a selected layer to label it
   if (selection === null || selection.count() === 0) {
     return messenger.toast('A layer must be selected');
   }
 
+  // grab the first layer in the selection and set up Identifier and Painter instances for it
   const layers = new Crawler({ for: selection });
   const layerToLabel = new Identifier({
     for: layers.first(),
@@ -84,14 +90,17 @@ const labelLayer = (context = null) => {
     messenger,
   });
   const painter = new Painter({ for: layers.first() });
+
+  // determine the label text
   const kitLayerLabel = layerToLabel.label();
 
-  // draw the label
+  // draw the label (if the text exists)
   let paintResult = null;
   if (kitLayerLabel) {
     paintResult = painter.addLabel(kitLayerLabel);
   }
 
+  // read the response from Painter; if it was unsuccessful, log and display the error
   if (paintResult && (paintResult.error || !paintResult.success)) {
     const toastMessage = paintResult.error && paintResult.messages.toast ? paintResult.messages.toast : 'An error occured';
     const logMessage = paintResult.error && paintResult.messages.log ? paintResult.messages.log : 'An error occured';
@@ -126,7 +135,7 @@ const onOpenDocument = (context) => {
 };
 
 /**
- * @description Writes to the log whenever the selection changes and display a Toast indicator.
+ * @description Writes to the log whenever the selection changes and displays a Toast indicator.
  *
  * @kind function
  * @name onSelectionChange

--- a/src/main.js
+++ b/src/main.js
@@ -42,7 +42,7 @@ const assemble = (context = null) => {
 const drawLabel = (context) => {
   const { selection } = assemble(context);
 
-  const painter = new Painter({ for: selection[0].parentArtboard() });
+  const painter = new Painter({ for: selection[0] });
   painter.addLabel('Hello, I am Component');
   return null;
 };
@@ -72,7 +72,7 @@ const labelLayer = (context = null) => {
     documentData,
     messenger,
   });
-  const painter = new Painter({ for: layerToLabel.artboard() });
+  const painter = new Painter({ for: layers.first() });
   const kitLayerLabel = layerToLabel.label();
 
   // draw the label

--- a/src/main.js
+++ b/src/main.js
@@ -33,19 +33,17 @@ const assemble = (context = null) => {
 // invoked commands -------------------------------------------------
 
 /**
- * @description Displays a “Hello World” Alert in the Sketch UI when invoked from the plugin menu.
+ * @description Temporary dev function to quickly draw an instance of a Component label.
  *
  * @kind function
- * @name helloWorld
+ * @name drawLabel
  * @param {Object} context The current context (event) received from Sketch.
  */
-const helloWorld = (context) => {
-  if (context.document) {
-    const { messenger } = assemble(context);
+const drawLabel = (context) => {
+  const { selection } = assemble(context);
 
-    messenger.alert('It’s alive 🙌', 'Hello');
-    messenger.log('It’s alive 🙌');
-  }
+  const painter = new Painter({ for: selection[0].parentArtboard() });
+  painter.addLabel('Hello, I am Component');
   return null;
 };
 
@@ -133,7 +131,7 @@ const onSelectionChange = (context) => {
 
 // export each used in manifest
 export {
-  helloWorld,
+  drawLabel,
   labelLayer,
   onOpenDocument,
   onSelectionChange,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,11 +9,11 @@
   "bundleVersion": 1,
   "commands": [
     {
-      "name": "Hello World",
-      "identifier": "hello-world",
-      "shortcut": "ctrl shift h",
+      "name": "Draw Label",
+      "identifier": "draw-label",
+      "shortcut": "ctrl shift d",
       "script": "./main.js",
-      "handler": "helloWorld"
+      "handler": "drawLabel"
     },
     {
       "name": "Label Component Symbol",
@@ -57,7 +57,7 @@
   "menu": {
     "title": "Auto-Spec",
     "items": [
-      "hello-world",
+      "draw-label",
       "label-component",
       "view-gui"
     ]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,11 +9,18 @@
   "bundleVersion": 1,
   "commands": [
     {
-      "name": "Draw Label",
+      "name": "Dev: Draw Label",
       "identifier": "draw-label",
       "shortcut": "ctrl shift d",
       "script": "./main.js",
       "handler": "drawLabel"
+    },
+    {
+      "name": "Dev: Reset Data",
+      "identifier": "reset-data",
+      "shortcut": "ctrl shift r",
+      "script": "./main.js",
+      "handler": "resetData"
     },
     {
       "name": "Label Component Symbol",
@@ -57,9 +64,10 @@
   "menu": {
     "title": "Auto-Spec",
     "items": [
-      "draw-label",
       "label-component",
-      "view-gui"
+      "view-gui",
+      "draw-label",
+      "reset-data"
     ]
   }
 }


### PR DESCRIPTION
<img width="946" alt="Screen Shot 2019-05-31 at 7 40 43 PM" src="https://user-images.githubusercontent.com/867428/58742864-0d423f80-83dc-11e9-962b-812e7b93f5ca.png">

The majority of the work in this PR falls into two related pieces: creating and drawing the actual labels in a Sketch file and adding a light data structure to track a link between the drawn labels and the original Sketch layer that was being labeled (i.e. received the label).

**Label Organization**
Once the first label is drawn, an artboard gets a container group that holds all of the drawn labels in one place. This helps keep the Sketch file neat and also allows the labels to be easily hidden, when necessary.

Inside the plugin settings, we track the existence of each container group in the `containerGroups` array, matching pairs of `artboardId` and `id`:

```js
containerGroups = (
  {
    artboardId = "6F969CE9-1F08-4B28-A1F5-546ADD1E3DF7";
    id = "884E01FE-8C23-458E-9358-62C390E0326A";
  }
);
```

**Label Tracking**
Labels are only drawn once. They do not get updated, but rather are deleted and re-drawn when the layer they represent is “re-labeled”. Tracking for all of this is handled in the `labeledLayers` key of the plugin settings:

```js
labeledLayers = (
  {
    containerGroupId = "884E01FE-8C23-458E-9358-62C390E0326A";
    id = "4CC0957C-3060-4B42-809F-444E016A1029";
    originalId = "06CCB90B-21E0-4A95-B704-C2CF42B8490B";
  }
);
```