### PR TITLE
“Annotate” instead of “Label”

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -91,7 +91,7 @@ svg {
   cursor: pointer;
 }
 
-.actions li.action-label a {
+.actions li.action-annotate a {
   display: block;
   width: 28px; /* 22px icon */
 }

--- a/resources/webview.html
+++ b/resources/webview.html
@@ -21,12 +21,12 @@
         </a>
       </li>
       <li class="action action-label">
-        <a href="#label" role="button" id="label" class="action-trigger">
-          <span class="text" aria-label="Label">
-            Label
+        <a href="#annotate" role="button" id="annotate" class="action-trigger">
+          <span class="text" aria-label="Annotate">
+            Annotate
           </span>
           <span class="icon">
-            <svg viewBox="0 0 21 18" class="icons-label">
+            <svg viewBox="0 0 21 18" class="icons-annotate">
               <path d="M2,13H8.17l2.39,2.32L13.4,13H19V2H2ZM0,0H21V15H14.11l-3.66,3L7.36,15H0Z"/>
             </svg>
           </span>

--- a/resources/webview.html
+++ b/resources/webview.html
@@ -20,7 +20,7 @@
           </span>
         </a>
       </li>
-      <li class="action action-label">
+      <li class="action action-annotate">
         <a href="#annotate" role="button" id="annotate" class="action-trigger">
           <span class="text" aria-label="Annotate">
             Annotate

--- a/resources/webview.js
+++ b/resources/webview.js
@@ -74,11 +74,11 @@ const AutoSpecWebview = {
       document.getElementById(trigger.id).addEventListener('click', () => {
         window.postMessage('nativeLog', `Called #${trigger.id} from the GUI`);
         switch (trigger.id) {
+          case 'annotate':
+            window.postMessage('annotateLayer');
+            break;
           case 'close':
             window.postMessage('closeWindow');
-            break;
-          case 'label':
-            window.postMessage('annotateLayer');
             break;
           default:
             window.postMessage('nativeLog', `Missing ${trigger.id} action`);

--- a/resources/webview.js
+++ b/resources/webview.js
@@ -78,7 +78,7 @@ const AutoSpecWebview = {
             window.postMessage('closeWindow');
             break;
           case 'label':
-            window.postMessage('labelLayer');
+            window.postMessage('annotateLayer');
             break;
           default:
             window.postMessage('nativeLog', `Missing ${trigger.id} action`);

--- a/src/GUI.js
+++ b/src/GUI.js
@@ -5,7 +5,7 @@ import BrowserWindow from 'sketch-module-web-view';
 import { getWebview } from 'sketch-module-web-view/remote';
 import Messenger from './Messenger';
 import * as theWebview from '../resources/webview.html';
-import { labelLayer } from './main';
+import { annotateLayer } from './main';
 import { PLUGIN_IDENTIFIER } from './constants';
 
 /**
@@ -86,8 +86,8 @@ const watchGui = () => {
   });
 
 
-  // call the labelLayer function in main.js
-  webContents.on('labelLayer', () => labelLayer());
+  // call the annotateLayer function in main.js
+  webContents.on('annotateLayer', () => annotateLayer());
 
   // close the webview window
   webContents.on('closeWindow', () => {

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -30,11 +30,11 @@ export default class Identifier {
    * from connected Lingo Kit symbols.
    *
    * @kind function
-   * @name label
+   * @name getName
    * @returns {Object} A result object containing the Kit-verified symbol name (`data`) along with
    * success/error bool and log/toast messages.
    */
-  label() {
+  getName() {
     const result = INITIAL_RESULT_STATE;
 
     // check for Lingo data - not much else we can do at the moment if it does not exist

--- a/src/main.js
+++ b/src/main.js
@@ -34,32 +34,6 @@ const assemble = (context = null) => {
 // invoked commands -------------------------------------------------
 
 /**
- * @description Temporary dev function to quickly draw an instance of a Component label.
- *
- * @kind function
- * @name drawAnnotation
- * @param {Object} context The current context (event) received from Sketch.
- */
-const drawAnnotation = (context) => {
-  const { selection } = assemble(context);
-
-  const painter = new Painter({ for: selection[0] });
-  painter.addLabel('Hello, I am Component');
-  return null;
-};
-
-/**
- * @description Temporary dev function to remove data in the `PLUGIN_IDENTIFIER` namespace.
- *
- * @kind function
- * @name resetData
- */
-const resetData = () => {
-  Settings.setSettingForKey(PLUGIN_IDENTIFIER, null);
-  return null;
-};
-
-/**
  * @description Identifies and labels a selected layer in a Sketch file.
  *
  * @kind function
@@ -111,6 +85,32 @@ const annotateLayer = (context = null) => {
     return null;
   });
 
+  return null;
+};
+
+/**
+ * @description Temporary dev function to quickly draw an instance of a Component label.
+ *
+ * @kind function
+ * @name drawAnnotation
+ * @param {Object} context The current context (event) received from Sketch.
+ */
+const drawAnnotation = (context) => {
+  const { selection } = assemble(context);
+
+  const painter = new Painter({ for: selection[0] });
+  painter.addLabel('Hello, I am Component');
+  return null;
+};
+
+/**
+ * @description Temporary dev function to remove data in the `PLUGIN_IDENTIFIER` namespace.
+ *
+ * @kind function
+ * @name resetData
+ */
+const resetData = () => {
+  Settings.setSettingForKey(PLUGIN_IDENTIFIER, null);
   return null;
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -74,7 +74,7 @@ const annotateLayer = (context = null) => {
     // draw the annotation (if the text exists)
     let paintResult = null;
     if (getNameResult && getNameResult.success && getNameResult.data) {
-      paintResult = painter.addLabel(getNameResult.data);
+      paintResult = painter.addAnnotation(getNameResult.data);
     }
 
     // read the response from Painter; if it was unsuccessful, log and display the error
@@ -99,7 +99,7 @@ const drawAnnotation = (context) => {
   const { selection } = assemble(context);
 
   const painter = new Painter({ for: selection[0] });
-  painter.addLabel('Hello, I am Component');
+  painter.addAnnotation('Hello, I am Component');
   return null;
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -37,10 +37,10 @@ const assemble = (context = null) => {
  * @description Temporary dev function to quickly draw an instance of a Component label.
  *
  * @kind function
- * @name drawLabel
+ * @name drawAnnotation
  * @param {Object} context The current context (event) received from Sketch.
  */
-const drawLabel = (context) => {
+const drawAnnotation = (context) => {
   const { selection } = assemble(context);
 
   const painter = new Painter({ for: selection[0] });
@@ -152,7 +152,7 @@ const onSelectionChange = (context) => {
 // export each used in manifest
 export {
   annotateLayer,
-  drawLabel,
+  drawAnnotation,
   onOpenDocument,
   onSelectionChange,
   resetData,

--- a/src/main.js
+++ b/src/main.js
@@ -34,7 +34,7 @@ const assemble = (context = null) => {
 // invoked commands -------------------------------------------------
 
 /**
- * @description Identifies and labels a selected layer in a Sketch file.
+ * @description Identifies and annotates a selected layer in a Sketch file.
  *
  * @kind function
  * @name annotateLayer
@@ -48,7 +48,7 @@ const annotateLayer = (context = null) => {
     selection,
   } = assemble(context);
 
-  // need a selected layer to label it
+  // need a selected layer to annotate it
   if (selection === null || selection.count() === 0) {
     return messenger.toast('A layer must be selected');
   }
@@ -57,7 +57,7 @@ const annotateLayer = (context = null) => {
   const layers = new Crawler({ for: selection });
   layers.all().forEach((layer) => {
     // set up Identifier instance for the layer
-    const layerToLabel = new Identifier({
+    const layerToAnnotate = new Identifier({
       for: layer,
       documentData,
       messenger,
@@ -65,16 +65,16 @@ const annotateLayer = (context = null) => {
     // set up Painter instance for the layer
     const painter = new Painter({ for: layer });
 
-    // determine the label text
-    const labelTextResult = layerToLabel.label();
-    if (labelTextResult && (labelTextResult.error || !labelTextResult.success)) {
-      return messenger.handleResult(labelTextResult);
+    // determine the annotation text
+    const getNameResult = layerToAnnotate.getName();
+    if (getNameResult && (getNameResult.error || !getNameResult.success)) {
+      return messenger.handleResult(getNameResult);
     }
 
-    // draw the label (if the text exists)
+    // draw the annotation (if the text exists)
     let paintResult = null;
-    if (labelTextResult && labelTextResult.success && labelTextResult.data) {
-      paintResult = painter.addLabel(labelTextResult.data);
+    if (getNameResult && getNameResult.success && getNameResult.data) {
+      paintResult = painter.addLabel(getNameResult.data);
     }
 
     // read the response from Painter; if it was unsuccessful, log and display the error
@@ -89,7 +89,7 @@ const annotateLayer = (context = null) => {
 };
 
 /**
- * @description Temporary dev function to quickly draw an instance of a Component label.
+ * @description Temporary dev function to quickly draw an instance of a Component annotation.
  *
  * @kind function
  * @name drawAnnotation

--- a/src/main.js
+++ b/src/main.js
@@ -63,11 +63,11 @@ const resetData = () => {
  * @description Identifies and labels a selected layer in a Sketch file.
  *
  * @kind function
- * @name labelLayer
+ * @name annotateLayer
  * @param {Object} context The current context (event) received from Sketch.
  * @returns {null} Shows a Toast in the UI if nothing is selected.
  */
-const labelLayer = (context = null) => {
+const annotateLayer = (context = null) => {
   const {
     documentData,
     messenger,
@@ -151,8 +151,8 @@ const onSelectionChange = (context) => {
 
 // export each used in manifest
 export {
+  annotateLayer,
   drawLabel,
-  labelLayer,
   onOpenDocument,
   onSelectionChange,
   resetData,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,10 +9,10 @@
   "bundleVersion": 1,
   "commands": [
     {
-      "name": "Dev: Draw Label",
-      "identifier": "dev-draw-label",
+      "name": "Dev: Draw Annotation",
+      "identifier": "dev-draw-annotation",
       "script": "./main.js",
-      "handler": "drawLabel"
+      "handler": "drawAnnotation"
     },
     {
       "name": "Dev: Reset Data",
@@ -64,7 +64,7 @@
     "items": [
       "annotate-layer",
       "view-gui",
-      "dev-draw-label",
+      "dev-draw-annotation",
       "dev-reset-data"
     ]
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,11 +21,11 @@
       "handler": "resetData"
     },
     {
-      "name": "Label Component Symbol",
-      "identifier": "label-component",
-      "shortcut": "ctrl shift i",
+      "name": "Annotate Component",
+      "identifier": "annotate-layer",
+      "shortcut": "ctrl shift a",
       "script": "./main.js",
-      "handler": "labelLayer"
+      "handler": "annotateLayer"
     },
     {
       "name" : "Selection Change Listener",
@@ -62,7 +62,7 @@
   "menu": {
     "title": "Spec’ing",
     "items": [
-      "label-component",
+      "annotate-layer",
       "view-gui",
       "dev-draw-label",
       "dev-reset-data"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Plugin to annotate symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
-  "version": "1.0-b005",
+  "version": "1.0-b006",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "compatibleVersion": 3,
   "bundleVersion": 1,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Spec’ing",
-  "description": "Plugin to label symbols",
+  "description": "Plugin to annotate symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
   "version": "1.0-b005",


### PR DESCRIPTION
The language we’re using in conversation has drifted away from the word “label” and to “annotate”. Updating the nomenclature used in the app to keep things from getting confusing down the road.