### PR TITLE
Update Settings

### DIFF
--- a/src/Housekeeper.js
+++ b/src/Housekeeper.js
@@ -27,25 +27,19 @@ export default class Housekeeper {
    * @kind function
    * @name runMigrations
    *
+   * @param {Object} comparisonKeys An object containing a `mainKey` and `secondaryKey` used
    * @param {Object} pluginSettings An object containing the plugin settings.
    * @param {Object} documentSettings An object containing the document settings.
-   * @param {Object} comparisonKeys An object containing a `mainKey` and `secondaryKey` used
    * in addition to `id` to compare layer ID sets between plugin and document settings.
    * @returns {Object} Returns an object containing (potentially) updated `documentSettings` and
    * `pluginSettings` objects, and a `changed` flag indicating updates.
    */
-  fromPluginToDocument(pluginSettings, documentSettings, comparisonKeys) {
+  fromPluginToDocument(comparisonKeys, pluginSettings, documentSettings = {}) {
     const { mainKey, secondaryKey, newMainKey } = comparisonKeys;
     const mainKeyToUse = newMainKey || mainKey;
-    let settingsChanged = false;
-    let newDocumentSettings = documentSettings;
+    const newDocumentSettings = documentSettings;
     let newPluginSettings = pluginSettings;
-
-    // set up `documentSettings` placeholder
-    if (!newDocumentSettings) {
-      newDocumentSettings = {};
-      newDocumentSettings[mainKey] = [];
-    }
+    let settingsChanged = false;
 
     // set up placeholder in `documentSettings` for the main key
     if (!newDocumentSettings[mainKey]) {
@@ -120,9 +114,9 @@ export default class Housekeeper {
       };
       this.messenger.log('Run “containerGroups” settings migration…');
       settingsToUpdate = this.fromPluginToDocument(
+        comparisonKeys,
         settingsToUpdate.pluginSettings,
         settingsToUpdate.documentSettings,
-        comparisonKeys,
       );
     }
 
@@ -135,9 +129,9 @@ export default class Housekeeper {
       };
       this.messenger.log('Run “labeledLayers” settings migration…');
       settingsToUpdate = this.fromPluginToDocument(
+        comparisonKeys,
         settingsToUpdate.pluginSettings,
         settingsToUpdate.documentSettings,
-        comparisonKeys,
       );
     }
 

--- a/src/Housekeeper.js
+++ b/src/Housekeeper.js
@@ -1,0 +1,108 @@
+import { Settings } from 'sketch';
+import { updateArray } from './Tools';
+import { PLUGIN_IDENTIFIER } from './constants';
+
+/** WIP
+ * @description A class to handle traversing an array of selected items and return useful items
+ * (parent layer, artboard, document, etc). It will also find items based on ID (or timestamp).
+ *
+ * @class
+ * @name Housekeeper
+ *
+ * @constructor
+ *
+ * @property selectionArray The array of selected items.
+ */
+export default class Housekeeper {
+  constructor({ in: document, messenger }) {
+    this.document = document;
+    this.messenger = messenger;
+  }
+
+  moveContainerGroupsToDocument(pluginSettings, documentSettings) {
+    let settingsChanged = false;
+    let newDocumentSettings = documentSettings;
+    let newPluginSettings = pluginSettings;
+    if (!newDocumentSettings) {
+      newDocumentSettings = {
+        containerGroups: [],
+      };
+    }
+
+    if (!newDocumentSettings.containerGroups) {
+      newDocumentSettings.containerGroups = [];
+    }
+
+    // iterate through each `containerGroup`
+    pluginSettings.containerGroups.forEach((containerGroupIdSet) => {
+      const { artboardId, id } = containerGroupIdSet;
+
+      // make sure the `artboard` layer actually exists
+      const artboard = this.document.getLayerWithID(artboardId);
+
+      // make sure the `containerGroup` layer actually exists
+      const containerGroup = this.document.getLayerWithID(id);
+
+      if (artboard && containerGroup) {
+        // check if this `containerGroup` has already been migrated
+        const existingItemIndex = newDocumentSettings.containerGroups.findIndex(
+          foundItem => (foundItem.id === id),
+        );
+        if (existingItemIndex < 0) {
+          newDocumentSettings.containerGroups.push({
+            artboardId,
+            id,
+          });
+
+          newPluginSettings = updateArray(
+            'containerGroups',
+            containerGroupIdSet,
+            newPluginSettings,
+            'remove',
+          );
+
+          // set the `changed` flag
+          settingsChanged = true;
+        }
+      }
+    });
+    return {
+      documentSettings: newDocumentSettings,
+      pluginSettings: newPluginSettings,
+      changed: settingsChanged,
+    };
+  }
+
+  /** WIP
+   * @description Returns the first item in the array.
+   *
+   * @kind function
+   * @name first
+   * @returns {Object} The first layer item in the array.
+   */
+  runMigrations() {
+    const pluginSettings = Settings.settingForKey(PLUGIN_IDENTIFIER);
+    const documentSettings = Settings.documentSettingForKey(this.document, PLUGIN_IDENTIFIER);
+    let settingsToUpdate = { changed: false };
+
+    if (!pluginSettings) {
+      return null;
+    }
+
+    if (pluginSettings.containerGroups && pluginSettings.containerGroups.length > 0) {
+      this.messenger.log('Run settings migration…');
+      settingsToUpdate = this.moveContainerGroupsToDocument(pluginSettings, documentSettings);
+    }
+
+    if (settingsToUpdate.changed) {
+      Settings.setDocumentSettingForKey(
+        this.document,
+        PLUGIN_IDENTIFIER,
+        settingsToUpdate.documentSettings,
+      );
+      Settings.setSettingForKey(PLUGIN_IDENTIFIER, settingsToUpdate.pluginSettings);
+      this.messenger.log('Migration: settings were updated');
+    }
+    return null;
+  }
+}

--- a/src/Housekeeper.js
+++ b/src/Housekeeper.js
@@ -2,16 +2,17 @@ import { Settings } from 'sketch';
 import { updateArray } from './Tools';
 import { PLUGIN_IDENTIFIER } from './constants';
 
-/** WIP
- * @description A class to handle traversing an array of selected items and return useful items
- * (parent layer, artboard, document, etc). It will also find items based on ID (or timestamp).
+/**
+ * @description A class to handle housekeeping tasks on Sketch, plugin, document, or
+ * layer Settings objects.
  *
  * @class
  * @name Housekeeper
  *
  * @constructor
  *
- * @property selectionArray The array of selected items.
+ * @property document The Sketch document that contains the layer.
+ * @property messenger An instance of the Messenger class.
  */
 export default class Housekeeper {
   constructor({ in: document, messenger }) {
@@ -19,6 +20,20 @@ export default class Housekeeper {
     this.messenger = messenger;
   }
 
+  /**
+   * @description Used to move plugin settings to document-level settings based on a set of
+   * keys used for comparisons.
+   *
+   * @kind function
+   * @name runMigrations
+   *
+   * @param {Object} pluginSettings An object containing the plugin settings.
+   * @param {Object} documentSettings An object containing the document settings.
+   * @param {Object} comparisonKeys An object containing a `mainKey` and `secondaryKey` used
+   * in addition to `id` to compare layer ID sets between plugin and document settings.
+   * @returns {Object} Returns an object containing (potentially) updated `documentSettings` and
+   * `pluginSettings` objects, and a `changed` flag indicating updates.
+   */
   fromPluginToDocument(pluginSettings, documentSettings, comparisonKeys) {
     const { mainKey, secondaryKey } = comparisonKeys;
     let settingsChanged = false;
@@ -76,12 +91,12 @@ export default class Housekeeper {
     };
   }
 
-  /** WIP
-   * @description Returns the first item in the array.
+  /**
+   * @description Checks for the existence of certain keys in the plugin Settings (`containerGroups`
+   * and `labeledLayers`) and runs any necessary migrations.
    *
    * @kind function
-   * @name first
-   * @returns {Object} The first layer item in the array.
+   * @name runMigrations
    */
   runMigrations() {
     const pluginSettings = Settings.settingForKey(PLUGIN_IDENTIFIER);

--- a/src/Housekeeper.js
+++ b/src/Housekeeper.js
@@ -35,7 +35,8 @@ export default class Housekeeper {
    * `pluginSettings` objects, and a `changed` flag indicating updates.
    */
   fromPluginToDocument(pluginSettings, documentSettings, comparisonKeys) {
-    const { mainKey, secondaryKey } = comparisonKeys;
+    const { mainKey, secondaryKey, newMainKey } = comparisonKeys;
+    const mainKeyToUse = newMainKey || mainKey;
     let settingsChanged = false;
     let newDocumentSettings = documentSettings;
     let newPluginSettings = pluginSettings;
@@ -64,12 +65,12 @@ export default class Housekeeper {
 
       if (primaryLayer && pairedLayer) {
         // check if this `primaryLayer` has already been migrated
-        const existingItemIndex = newDocumentSettings[mainKey].findIndex(
+        const existingItemIndex = newDocumentSettings[mainKeyToUse].findIndex(
           foundItem => (foundItem.id === id),
         );
         if (existingItemIndex < 0) {
           // add the `layerIdSet` to the document settings
-          newDocumentSettings[mainKey].push(layerIdSet);
+          newDocumentSettings[mainKeyToUse].push(layerIdSet);
 
           // remove the `layerIdSet` from the plugin settings
           newPluginSettings = updateArray(
@@ -125,10 +126,11 @@ export default class Housekeeper {
       );
     }
 
-    // migrate the `labeledLayers` into local document settings
+    // migrate the `labeledLayers` into local document settings as `annotatedLayeres`
     if (pluginSettings.labeledLayers && pluginSettings.labeledLayers.length > 0) {
       const comparisonKeys = {
         mainKey: 'labeledLayers',
+        newMainKey: 'annotatedLayers',
         secondaryKey: 'originalId',
       };
       this.messenger.log('Run “labeledLayers” settings migration…');

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -1,5 +1,5 @@
-import { fromNative } from 'sketch';
-import { INITIAL_RESULT_STATE } from './constants';
+import { fromNative, Settings } from 'sketch';
+import { INITIAL_RESULT_STATE, PLUGIN_IDENTIFIER } from './constants';
 
 /**
  * @description A class to handle identifying a Sketch layer as a valid part of the Design System.
@@ -25,17 +25,17 @@ export default class Identifier {
   }
 
   /**
-   * @description Returns Kit-verified master symbol name of a layer. Cross-references
-   * a symbol’s `symbolId` with the master symbol instance, and looks the name up
-   * from connected Lingo Kit symbols.
+   * @description Identifies the Kit-verified master symbol name of a layer and adds it to the
+   * layer’s settings object: Cross-references a symbol’s `symbolId` with the master symbol
+   * instance, and looks the name up from connected Lingo Kit symbols.
    *
    * @kind function
    * @name getName
-   * @returns {Object} A result object containing the Kit-verified symbol name (`data`) along with
-   * success/error bool and log/toast messages.
+   * @returns {Object} A result object container success/error bool and log/toast messages.
    */
   getName() {
     const result = INITIAL_RESULT_STATE;
+    let settings = Settings.layerSettingForKey(this.layer, PLUGIN_IDENTIFIER);
 
     // check for Lingo data - not much else we can do at the moment if it does not exist
     if (
@@ -84,10 +84,19 @@ export default class Identifier {
     // otherwise, fall back to the kit symbol name
     kitSymbolNameClean = !kitSymbolNameClean ? kitSymbol.name : kitSymbolNameClean;
 
-    // return the official name and log it alongside the original layer name
+    // set `annotationText` on the layer settings as the kit symbol name
+    if (!settings) {
+      settings = {
+        annotationText: kitSymbolNameClean,
+      };
+    } else {
+      settings.annotationText = kitSymbolNameClean;
+    }
+    Settings.setLayerSettingForKey(this.layer, PLUGIN_IDENTIFIER, settings);
+
+    // log the official name alongside the original layer name and set as success
     result.success = true;
     result.messages.log = `Name in Lingo Kit for “${this.layer.name()}” is “${kitSymbolNameClean}”`;
-    result.data = kitSymbolNameClean;
     return result;
   }
 

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -31,7 +31,7 @@ export default class Identifier {
    *
    * @kind function
    * @name getName
-   * @returns {Object} A result object container success/error bool and log/toast messages.
+   * @returns {Object} A result object containing success/error status and log/toast messages.
    */
   getName() {
     const result = INITIAL_RESULT_STATE;

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -35,7 +35,7 @@ export default class Identifier {
    */
   getName() {
     const result = INITIAL_RESULT_STATE;
-    let settings = Settings.layerSettingForKey(this.layer, PLUGIN_IDENTIFIER);
+    let layerSettings = Settings.layerSettingForKey(this.layer, PLUGIN_IDENTIFIER);
 
     // check for Lingo data - not much else we can do at the moment if it does not exist
     if (
@@ -85,14 +85,14 @@ export default class Identifier {
     kitSymbolNameClean = !kitSymbolNameClean ? kitSymbol.name : kitSymbolNameClean;
 
     // set `annotationText` on the layer settings as the kit symbol name
-    if (!settings) {
-      settings = {
+    if (!layerSettings) {
+      layerSettings = {
         annotationText: kitSymbolNameClean,
       };
     } else {
-      settings.annotationText = kitSymbolNameClean;
+      layerSettings.annotationText = kitSymbolNameClean;
     }
-    Settings.setLayerSettingForKey(this.layer, PLUGIN_IDENTIFIER, settings);
+    Settings.setLayerSettingForKey(this.layer, PLUGIN_IDENTIFIER, layerSettings);
 
     // log the official name alongside the original layer name and set as success
     result.success = true;

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -372,7 +372,7 @@ export default class Painter {
     const layerSettings = Settings.layerSettingForKey(this.layer, PLUGIN_IDENTIFIER);
 
     if (!layerSettings || (layerSettings && !layerSettings.annotationText)) {
-      result.error = true;
+      result.status = 'true';
       result.messages.log = 'Layer missing annotationText';
       return result;
     }
@@ -400,22 +400,20 @@ export default class Painter {
 
     // check if we have already annotated this element and remove the old annotation
     if (documentSettings && documentSettings.labeledLayers) {
-      const existingItemData = documentSettings.labeledLayers.find(
-        foundItem => (foundItem.originalId === layerId),
-      );
+      // remove the old ID pair(s) from the `newDocumentSettings` array
+      documentSettings.labeledLayers.forEach((layerSet) => {
+        if (layerSet.originalId === layerId) {
+          this.removeAnnotation(layerSet);
 
-      // remove the old ID pair from the `newDocumentSettings` array
-      if (existingItemData) {
-        this.removeAnnotation(existingItemData);
-
-        // remove the ID that cannot be found from the `newDocumentSettings` array
-        newDocumentSettings = updateArray(
-          'labeledLayers',
-          { id: existingItemData.id },
-          newDocumentSettings,
-          'remove',
-        );
-      }
+          // remove the ID that cannot be found from the `newDocumentSettings` array
+          newDocumentSettings = updateArray(
+            'labeledLayers',
+            { id: layerSet.id },
+            newDocumentSettings,
+            'remove',
+          );
+        }
+      });
     }
 
     // construct the base annotation elements

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -404,7 +404,7 @@ export default class Painter {
         foundItem => (foundItem.originalId === layerId),
       );
 
-      // remove old annotation layer + remove from data
+      // remove the old ID pair from the `newDocumentSettings` array
       if (existingItemData) {
         this.removeAnnotation(existingItemData);
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -390,8 +390,17 @@ export default class Painter {
    * @param {Array} annotationText The text for the annotation.
    * @returns {Object} A result object container success/error bool and log/toast messages.
    */
-  addAnnotation(annotationText = 'New Annotation') {
+  addAnnotation() {
     const result = INITIAL_RESULT_STATE;
+    const settings = Settings.layerSettingForKey(this.layer, PLUGIN_IDENTIFIER);
+
+    if (!settings || (settings && !settings.annotationText)) {
+      result.error = true;
+      result.messages.log = 'Layer missing annotationText';
+      return result;
+    }
+
+    const { annotationText } = settings;
 
     // return an error if the selection is not placed on an artboard
     if (!this.artboard) {
@@ -405,14 +414,14 @@ export default class Painter {
     const layerName = this.layer.name();
     const layerId = fromNative(this.layer).id;
     const groupName = `Annotation for ${layerName}`;
-    const settings = Settings.settingForKey(PLUGIN_IDENTIFIER);
+    const pluginSettings = Settings.settingForKey(PLUGIN_IDENTIFIER);
 
     // create or locate the container group
     const containerGroup = setContainerGroup(this.artboard);
 
     // check if we have already annotated this element and remove the old annotation
-    if (settings && settings.labeledLayers) {
-      const existingItemData = settings.labeledLayers.find(
+    if (pluginSettings && pluginSettings.labeledLayers) {
+      const existingItemData = pluginSettings.labeledLayers.find(
         foundItem => (foundItem.originalId === layerId),
       );
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -5,7 +5,7 @@ import {
   ShapePath,
   Text,
 } from 'sketch/dom';
-import { findLayerById, updateArray } from './Tools';
+import { updateArray } from './Tools';
 import {
   INITIAL_RESULT_STATE,
   PLUGIN_IDENTIFIER,
@@ -340,7 +340,7 @@ const setContainerGroup = (artboard, document) => {
       }
       return null;
     });
-    containerGroup = findLayerById(artboard.layers(), containerGroupId);
+    containerGroup = document.getLayerWithID(containerGroupId);
   }
 
   // create a new `containerGroup` if one does not exist (or it cannot be found)
@@ -405,12 +405,9 @@ export default class Painter {
    * the original layer that received the annotation.
    */
   removeAnnotation(existingItemData) {
-    const layerContainer = findLayerById(this.artboard.layers(), existingItemData.containerGroupId);
-    if (layerContainer) {
-      const layerToDelete = findLayerById(layerContainer.layers(), existingItemData.id);
-      if (layerToDelete) {
-        fromNative(layerToDelete).remove(); // .remove() only works on a js object, not obj-c
-      }
+    const layerToDelete = this.document.getLayerWithID(existingItemData.id);
+    if (layerToDelete) {
+      fromNative(layerToDelete).remove(); // .remove() only works on a js object, not obj-c
     }
   }
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -205,13 +205,16 @@ const positionAnnotationElements = (containerGroup, groupName, annotationElement
   return group;
 };
 
-/** WIP
- * @description Builds the parent container group that holds all of the annotations.
+/**
+ * @description Builds the parent container group that holds all of the annotations and makes
+ * updates to the accompanying document settings object.
  *
  * @kind function
  * @name createContainerGroup
  * @param {Object} artboard The artboard to draw within.
- * @returns {Object} The container group layer.
+ * @param {Object} documentSettings An instance of the document’s settings object.
+ * @returns {Object} The container group layer object and the accompanying
+ * updated document settings object.
  * @private
  */
 const createContainerGroup = (artboard, documentSettings) => {
@@ -256,12 +259,14 @@ const createContainerGroup = (artboard, documentSettings) => {
   };
 };
 
-/** WIP
- * @description Sets (finds or builds) the parent container group.
+/**
+ * @description Sets (finds or builds) the parent container group and
+ * updates the document settings (if a new container group has been created).
  *
  * @kind function
  * @name createContainerGroup
  * @param {Object} artboard The artboard to draw within.
+ * @param {Object} document The document to draw within.
  * @returns {Object} The container group layer.
  * @private
  */
@@ -342,6 +347,7 @@ export default class Painter {
    *
    * @kind function
    * @name removeAnnotation
+   *
    * @param {Object} existingItemData The data object containing a
    * `containerGroupId`, `id` (representting the annotation) and `layerId` representing
    * the original layer that received the annotation.
@@ -354,12 +360,12 @@ export default class Painter {
   }
 
   /**
-   * @description Takes a layer name and builds the visual annotation on the Sketch artboard.
+   * @description Locates annotation text in a layer’s Settings object and
+   * builds the visual annotation on the Sketch artboard.
    *
    * @kind function
    * @name addAnnotation
-   * @param {Array} annotationText The text for the annotation.
-   * @returns {Object} A result object container success/error bool and log/toast messages.
+   * @returns {Object} A result object container success/error status and log/toast messages.
    */
   addAnnotation() {
     const result = INITIAL_RESULT_STATE;

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -24,7 +24,6 @@ import {
  * @type {Object}
  */
 const initialSettingsState = {
-  containerGroups: [],
   labeledLayers: [],
 };
 

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -399,15 +399,15 @@ export default class Painter {
     let newDocumentSettings = documentSettings;
 
     // check if we have already annotated this element and remove the old annotation
-    if (documentSettings && documentSettings.labeledLayers) {
+    if (documentSettings && documentSettings.annotatedLayers) {
       // remove the old ID pair(s) from the `newDocumentSettings` array
-      documentSettings.labeledLayers.forEach((layerSet) => {
+      documentSettings.annotatedLayers.forEach((layerSet) => {
         if (layerSet.originalId === layerId) {
           this.removeAnnotation(layerSet);
 
           // remove the ID that cannot be found from the `newDocumentSettings` array
           newDocumentSettings = updateArray(
-            'labeledLayers',
+            'annotatedLayers',
             { id: layerSet.id },
             newDocumentSettings,
             'remove',
@@ -436,7 +436,7 @@ export default class Painter {
     );
 
     // new object with IDs to add to settings
-    const newLabeledLayerSet = {
+    const newAnnotatedLayerSet = {
       containerGroupId: fromNative(containerGroup).id,
       id: group.id,
       originalId: layerId,
@@ -444,8 +444,8 @@ export default class Painter {
 
     // update the `newDocumentSettings` array
     newDocumentSettings = updateArray(
-      'labeledLayers',
-      newLabeledLayerSet,
+      'annotatedLayers',
+      newAnnotatedLayerSet,
       newDocumentSettings,
       'add',
     );

--- a/src/Painter.js
+++ b/src/Painter.js
@@ -357,8 +357,9 @@ const setContainerGroup = (artboard) => {
  * @property layer The layer in the Sketch file that we want to annotate or modify.
  */
 export default class Painter {
-  constructor({ for: layer }) {
+  constructor({ for: layer, in: document }) {
     this.layer = layer;
+    this.document = document;
     this.artboard = this.layer.parentArtboard();
   }
 
@@ -392,15 +393,15 @@ export default class Painter {
    */
   addAnnotation() {
     const result = INITIAL_RESULT_STATE;
-    const settings = Settings.layerSettingForKey(this.layer, PLUGIN_IDENTIFIER);
+    const layerSettings = Settings.layerSettingForKey(this.layer, PLUGIN_IDENTIFIER);
 
-    if (!settings || (settings && !settings.annotationText)) {
+    if (!layerSettings || (layerSettings && !layerSettings.annotationText)) {
       result.error = true;
       result.messages.log = 'Layer missing annotationText';
       return result;
     }
 
-    const { annotationText } = settings;
+    const { annotationText } = layerSettings;
 
     // return an error if the selection is not placed on an artboard
     if (!this.artboard) {

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -73,9 +73,49 @@ const findLayerById = (layers, layerId) => {
   return foundLayer;
 };
 
+/** WIP
+ * @description Adds or removes data from the data set based on a key and
+ * an action (`add` or `remove`).
+ *
+ * @kind function
+ * @name updateArray
+ * @param {string} key String representing the area of Settings to modify.
+ * @param {Object} data Object containing the bit of data to add or
+ * remove (must include an `id` string).
+ * @param {string} action Constant string representing the action to take (`add` or `remove`).
+ * @returns {Object} The modified data set.
+ * @private
+ */
+const updateArray = (key, item, array, action = 'add') => {
+  const updatedArray = array;
+
+  if (action === 'add') {
+    if (!updatedArray[key]) {
+      updatedArray[key] = [];
+    }
+
+    updatedArray[key].push(item);
+  }
+
+  if (action === 'remove') {
+    let updatedItems = null;
+    // find the items updatedArray index of the item to remove
+    const itemIndex = updatedArray[key].findIndex(foundItem => (foundItem.id === item.id));
+
+    updatedItems = [
+      ...updatedArray[key].slice(0, itemIndex),
+      ...updatedArray[key].slice(itemIndex + 1),
+    ];
+
+    updatedArray[key] = updatedItems;
+  }
+  return updatedArray;
+};
+
 export {
   findLayerById,
   getDocument,
   getSelection,
   setArray,
+  updateArray,
 };

--- a/src/Tools.js
+++ b/src/Tools.js
@@ -73,17 +73,19 @@ const findLayerById = (layers, layerId) => {
   return foundLayer;
 };
 
-/** WIP
- * @description Adds or removes data from the data set based on a key and
+/**
+ * @description A reusable helper function to take an array and add or remove data from it
+ * based on a top-level key and a defined action.
  * an action (`add` or `remove`).
  *
  * @kind function
  * @name updateArray
- * @param {string} key String representing the area of Settings to modify.
- * @param {Object} data Object containing the bit of data to add or
- * remove (must include an `id` string).
+ * @param {string} key String representing the top-level area of the array to modify.
+ * @param {Object} item Object containing the new bit of data to add or
+ * remove (must include an `id` string for comparison).
+ * @param {Array} array The array to be modified.
  * @param {string} action Constant string representing the action to take (`add` or `remove`).
- * @returns {Object} The modified data set.
+ * @returns {Object} The modified array.
  * @private
  */
 const updateArray = (key, item, array, action = 'add') => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -36,7 +36,6 @@ const INITIAL_RESULT_STATE = {
     toast: null,
     log: null,
   },
-  data: null,
 };
 
 export {

--- a/src/main.js
+++ b/src/main.js
@@ -97,9 +97,12 @@ const annotateLayer = (context = null) => {
  */
 const drawAnnotation = (context) => {
   const { selection } = assemble(context);
+  const layer = selection[0];
+  const settings = { annotationText: 'Hello, I am Component' };
+  Settings.setLayerSettingForKey(layer, PLUGIN_IDENTIFIER, settings);
 
   const painter = new Painter({ for: selection[0] });
-  painter.addAnnotation('Hello, I am Component');
+  painter.addAnnotation();
   return null;
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -43,6 +43,7 @@ const assemble = (context = null) => {
  */
 const annotateLayer = (context = null) => {
   const {
+    document,
     documentData,
     messenger,
     selection,
@@ -63,7 +64,7 @@ const annotateLayer = (context = null) => {
       messenger,
     });
     // set up Painter instance for the layer
-    const painter = new Painter({ for: layer });
+    const painter = new Painter({ for: layer, in: document });
 
     // determine the annotation text
     const getNameResult = layerToAnnotate.getName();
@@ -96,12 +97,12 @@ const annotateLayer = (context = null) => {
  * @param {Object} context The current context (event) received from Sketch.
  */
 const drawAnnotation = (context) => {
-  const { selection } = assemble(context);
+  const { document, selection } = assemble(context);
   const layer = selection[0];
-  const settings = { annotationText: 'Hello, I am Component' };
-  Settings.setLayerSettingForKey(layer, PLUGIN_IDENTIFIER, settings);
+  const layerSettings = { annotationText: 'Hello, I am Component' };
+  Settings.setLayerSettingForKey(layer, PLUGIN_IDENTIFIER, layerSettings);
 
-  const painter = new Painter({ for: selection[0] });
+  const painter = new Painter({ for: selection[0], in: document });
   painter.addAnnotation();
   return null;
 };

--- a/src/main.js
+++ b/src/main.js
@@ -110,17 +110,6 @@ const drawAnnotation = (context) => {
   return null;
 };
 
-/**
- * @description Temporary dev function to remove data in the `PLUGIN_IDENTIFIER` namespace.
- *
- * @kind function
- * @name resetData
- */
-const resetData = () => {
-  Settings.setSettingForKey(PLUGIN_IDENTIFIER, null);
-  return null;
-};
-
 // listeners -------------------------------------------------
 
 /**
@@ -170,5 +159,4 @@ export {
   drawAnnotation,
   onOpenDocument,
   onSelectionChange,
-  resetData,
 };

--- a/src/main.js
+++ b/src/main.js
@@ -73,8 +73,8 @@ const annotateLayer = (context = null) => {
 
     // draw the annotation (if the text exists)
     let paintResult = null;
-    if (getNameResult && getNameResult.success && getNameResult.data) {
-      paintResult = painter.addAnnotation(getNameResult.data);
+    if (getNameResult && getNameResult.success) {
+      paintResult = painter.addAnnotation();
     }
 
     // read the response from Painter; if it was unsuccessful, log and display the error

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,10 @@
 import { fromNative, Settings } from 'sketch';
 
 import Crawler from './Crawler';
-import Painter from './Painter';
+import Housekeeper from './Housekeeper';
 import Identifier from './Identifier';
 import Messenger from './Messenger';
+import Painter from './Painter';
 import { getDocument, getSelection } from './Tools';
 import { PLUGIN_IDENTIFIER } from './constants';
 
@@ -21,11 +22,13 @@ const assemble = (context = null) => {
   const jsDocument = fromNative(objcDocument); // move from obj-c object to JSON object
   const documentData = objcDocument.documentData(); // obj-c object
   const messenger = new Messenger({ for: context, in: jsDocument });
+  const housekeeper = new Housekeeper({ in: jsDocument, messenger });
   const selection = getSelection(objcDocument);
 
   return {
     document: jsDocument,
     documentData,
+    housekeeper,
     messenger,
     selection,
   };
@@ -129,10 +132,18 @@ const resetData = () => {
  */
 const onOpenDocument = (context) => {
   if (context.actionContext.document) {
-    const { document, messenger } = assemble(context);
+    const {
+      document,
+      housekeeper,
+      messenger,
+    } = assemble(context);
 
     if (document) {
       messenger.log(`Document “${document.id}” Opened 😻`);
+
+      setTimeout(() => {
+        housekeeper.runMigrations();
+      }, 500);
     }
   }
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,12 +15,6 @@
       "handler": "drawAnnotation"
     },
     {
-      "name": "Dev: Reset Data",
-      "identifier": "dev-reset-data",
-      "script": "./main.js",
-      "handler": "resetData"
-    },
-    {
       "name": "Annotate Component",
       "identifier": "annotate-layer",
       "shortcut": "ctrl shift a",
@@ -64,8 +58,7 @@
     "items": [
       "annotate-layer",
       "view-gui",
-      "dev-draw-annotation",
-      "dev-reset-data"
+      "dev-draw-annotation"
     ]
   }
 }


### PR DESCRIPTION
Makes some changes to how we handle data that will serve us better in upcoming features. The concepts from #6 remain essentially the same, but everything is now tied directly to a Sketch _document’s_ settings rather than the plugin’s settings.

Additionally, the `Identifier` now writes a layer’s annotation text to the _layer_ settings so that `Painter` can read from it without the plugin needing to pass data between the two classes.

#### Introducing `Housekeeper`

The new `Housekeeper` class helps with data migrations for anyone already using the plugin. We can use this class for future data structure updates and other similar tasks. The existing migrations are currently run when a document is opened in Sketch, but only if relevant data exists in both the plugin and document settings.