### PR TITLE
Publishing Changes

### DIFF
--- a/.appcast.xml
+++ b/.appcast.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
   <channel>
+    <item>
+      <enclosure url="https://github.com/linkedinlabs/sketch-auto-spec.git/releases/download/v0.0.6/sketch-speccing.sketchplugin.zip" sparkle:version="0.0.6"/>
+    </item>
   </channel>
 </rss>

--- a/.appcast.xml
+++ b/.appcast.xml
@@ -2,9 +2,6 @@
 <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
   <channel>
     <item>
-      <enclosure url="https://github.com/linkedinlabs/sketch-auto-spec/releases/download/v1.0.0-beta.7/sketch-speccing.sketchplugin.zip" sparkle:version="1.0.0-beta.7"/>
-    </item>
-    <item>
       <enclosure url="https://github.com/linkedinlabs/sketch-auto-spec/releases/download/v1.0.0-beta.6/sketch-speccing.sketchplugin.zip" sparkle:version="1.0.0-beta.6"/>
     </item>
   </channel>

--- a/.appcast.xml
+++ b/.appcast.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
   <channel>
-    <item>
-      <enclosure url="https://github.com/linkedinlabs/sketch-auto-spec/releases/download/v1.0.0-beta.6/sketch-speccing.sketchplugin.zip" sparkle:version="1.0.0-beta.6"/>
-    </item>
   </channel>
 </rss>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-speccing",
-  "version": "1.0.0-beta.6",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-speccing",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-speccing",
   "description": "A Sketch plugin for easily spec’ing design system components.",
-  "version": "1.0.0-beta.6",
+  "version": "0.0.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/sketch-auto-spec.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-speccing",
   "description": "A Sketch plugin for easily spec’ing design system components.",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/sketch-auto-spec.git"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Plugin to annotate symbols",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
-  "version": "1.0.0-beta.7",
+  "version": "0.0.6",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "appcast": "https://raw.githubusercontent.com/github.com/linkedinlabs/sketch-auto-spec/master/.appcast.xml",
   "compatibleVersion": "55.0",


### PR DESCRIPTION
The Sketch auto-updater wasn’t able to read the `-beta.x` versioning we were using. Reseting the version to `0.0.6` so that we can use auto-updates.