### PR TITLE
Symbol Overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-specter",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-specter",
   "description": "A Sketch plugin for easily spec’ing design system elements.",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/sketch-auto-spec.git"

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -120,7 +120,16 @@ const parseOverrides = (layer, document) => {
         overrideTypeName.toLowerCase().includes('icon')
         && !overrideTypeName.toLowerCase().includes('color')
       ) {
-        const iconName = overrideName.split('/').pop();
+        // default icon name (usually last element of the name)
+        let iconName = overrideName.split('/').pop();
+
+        // ---------- set up exceptions
+        // parsing exception for Ghost Entity symbols
+        if (overrideTypeName.toLowerCase().includes('ghost')) {
+          iconName = overrideName.split('/').reverse()[1]; // eslint-disable-line prefer-destructuring
+        }
+
+        // set final text
         overridesText = `Override: ${iconName}`;
       }
     }

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -101,7 +101,7 @@ const cleanName = (name) => {
  * @private
  */
 const parseOverrides = (layer, document) => {
-  let overridesText = null;
+  const overridesText = [];
 
   // iterate available overrides
   fromNative(layer).overrides.forEach((override) => {
@@ -121,7 +121,8 @@ const parseOverrides = (layer, document) => {
       // grab name (sometimes it does not exist if “None” is a changed override)
       const overrideName = overrideSymbol ? overrideSymbol.name : null;
 
-      // look for Icon overrides
+      // look for Icon overrides - this is based on parsing the text of an
+      // `overrideTypeName` and making some comparisons and exceptions
       if (
         overrideName && (
           (
@@ -148,13 +149,19 @@ const parseOverrides = (layer, document) => {
           }
         }
 
-        // set final text
-        overridesText = `Override: ${iconName}`;
+        // update `overridesText`
+        overridesText.push(iconName);
       }
     }
   });
 
-  return overridesText;
+  let label = 'Override';
+  if (overridesText.length > 1) {
+    label = 'Overrides';
+  }
+  const setOverridesText = `${label}: ${overridesText.join(',')}`;
+
+  return setOverridesText;
 };
 
 // --- main Identifier class function

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -114,18 +114,21 @@ const parseOverrides = (layer, document) => {
 
       // current override master symbol (ID is the override value)
       const overrideSymbol = document.getSymbolMasterWithID(override.value);
-      const overrideName = overrideSymbol.name;
+      // grab name (sometimes it does not exist if “None” is a changed override)
+      const overrideName = overrideSymbol ? overrideSymbol.name : null;
 
       // look for Icon overrides
       if (
-        (
-          overrideTypeName.toLowerCase().includes('icon')
-          && !overrideTypeName.toLowerCase().includes('color')
-          && !overrideTypeName.toLowerCase().includes('🎨')
+        overrideName && (
+          (
+            overrideTypeName.toLowerCase().includes('icon')
+            && !overrideTypeName.toLowerCase().includes('color')
+            && !overrideTypeName.toLowerCase().includes('🎨')
+          )
+          || overrideTypeName.toLowerCase() === 'checkbox'
+          || overrideTypeName.toLowerCase() === 'radio'
+          || overrideTypeName.toLowerCase() === 'type'
         )
-        || overrideTypeName.toLowerCase() === 'checkbox'
-        || overrideTypeName.toLowerCase() === 'radio'
-        || overrideTypeName.toLowerCase() === 'type'
       ) {
         // default icon name (usually last element of the name, separated by “/”)
         let iconName = overrideName.split(/(?:[^w])(\/)/).pop();

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -77,6 +77,7 @@ const checkNameForType = (name) => {
  */
 const cleanName = (name) => {
   // take only the last segment of the name (after a “/”, if available)
+
   let cleanedName = name.split('/').pop();
   // otherwise, fall back to the kit layer name
   cleanedName = !cleanedName ? name : cleanedName;
@@ -117,8 +118,11 @@ const parseOverrides = (layer, document) => {
 
       // look for Icon overrides
       if (
-        (overrideTypeName.toLowerCase().includes('icon')
-          && !overrideTypeName.toLowerCase().includes('color'))
+        (
+          overrideTypeName.toLowerCase().includes('icon')
+          && !overrideTypeName.toLowerCase().includes('color')
+          && !overrideTypeName.toLowerCase().includes('🎨')
+        )
         || overrideTypeName.toLowerCase() === 'checkbox'
         || overrideTypeName.toLowerCase() === 'radio'
         || overrideTypeName.toLowerCase() === 'type'

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -117,13 +117,16 @@ const parseOverrides = (layer, document) => {
 
       // look for Icon overrides
       if (
-        overrideTypeName.toLowerCase().includes('icon')
-        && !overrideTypeName.toLowerCase().includes('color')
+        (overrideTypeName.toLowerCase().includes('icon')
+          && !overrideTypeName.toLowerCase().includes('color'))
+        || overrideTypeName.toLowerCase() === 'checkbox'
+        || overrideTypeName.toLowerCase() === 'radio'
+        || overrideTypeName.toLowerCase() === 'type'
       ) {
         // default icon name (usually last element of the name)
         let iconName = overrideName.split('/').pop();
 
-        // ---------- set up exceptions
+        // ---------- set up formatting exceptions
         // parsing exception for Ghost Entity symbols
         if (overrideTypeName.toLowerCase().includes('ghost')) {
           iconName = overrideName.split('/').reverse()[1]; // eslint-disable-line prefer-destructuring

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -123,41 +123,38 @@ const parseOverrides = (layer, document, workingName = null) => {
       const overrideName = overrideSymbol ? overrideSymbol.name : null;
 
       if (overrideName) {
-        // look for top-level overrides
-        if (!override.path.includes('/')) {
-          let topLevelOverrideName = overrideName.split(/(?:[^w])(\/)/).pop();
-          topLevelOverrideName = topLevelOverrideName.replace(`${workingName}`, '');
-          // update `overridesText`
-          overridesText.push(topLevelOverrideName);
-        }
-        // look for Icon overrides - this is based on parsing the text of an
-        // `overrideTypeName` and making some comparisons and exceptions
+        // look for top-level overrides and Icon overrides - based on
+        // parsing the text of an `overrideTypeName` and making some
+        // comparisons and exceptions
         if (
           (
             overrideTypeName.toLowerCase().includes('icon')
             && !overrideTypeName.toLowerCase().includes('color')
             && !overrideTypeName.toLowerCase().includes('🎨')
+            && !overrideTypeName.toLowerCase().includes('button')
           )
           || overrideTypeName.toLowerCase() === 'checkbox'
           || overrideTypeName.toLowerCase() === 'radio'
           || overrideTypeName.toLowerCase() === 'type'
           || overrideTypeName.toLowerCase().includes('pebble')
+          || !override.path.includes('/')
         ) {
           // default icon name (usually last element of the name, separated by “/”)
-          let iconName = overrideName.split(/(?:[^w])(\/)/).pop();
+          let overrideValueName = overrideName.split(/(?:[^w])(\/)/).pop();
+          overrideValueName = overrideValueName.replace(`${workingName}`, '');
 
           // ---------- set up formatting exceptions
           // parsing exception for Ghost Entity symbols
           if (overrideTypeName.toLowerCase().includes('ghost')) {
             // in some kits, Ghost naming scheme is fine
             // but in the Web kit it is reversed: “…/Article Ghost/3” instead of “…/3/Article Ghost”
-            if (Number(iconName) === parseInt(iconName, 10)) {
-              iconName = overrideName.split('/').reverse()[1]; // eslint-disable-line prefer-destructuring
+            if (Number(overrideValueName) === parseInt(overrideValueName, 10)) {
+              overrideValueName = overrideName.split('/').reverse()[1]; // eslint-disable-line prefer-destructuring
             }
           }
 
           // update `overridesText`
-          overridesText.push(iconName);
+          overridesText.push(overrideValueName);
         }
       }
     }

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -54,7 +54,11 @@ const setAnnotationTextSettings = (
 const checkNameForType = (name) => {
   let annotationType = 'component';
   // grab the first segment of the name (before the first “/”) – top-level Kit name
-  const kitName = name.split('/')[0];
+  let kitName = name.split('/')[0];
+
+  // set up some known exceptions (remove the text that would trigger a type change)
+  kitName = kitName.replace('(Dual Icons)', '');
+
   // kit name substrings, exclusive to Foundations
   const foundations = ['Divider', 'Flood', 'Icons', 'Illustration', 'Logos'];
 
@@ -128,6 +132,7 @@ const parseOverrides = (layer, document) => {
           || overrideTypeName.toLowerCase() === 'checkbox'
           || overrideTypeName.toLowerCase() === 'radio'
           || overrideTypeName.toLowerCase() === 'type'
+          || overrideTypeName.toLowerCase().includes('pebble')
         )
       ) {
         // default icon name (usually last element of the name, separated by “/”)

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -78,7 +78,7 @@ const checkNameForType = (name) => {
 const cleanName = (name) => {
   // take only the last segment of the name (after a “/”, if available)
 
-  let cleanedName = name.split('/').pop();
+  let cleanedName = name.split(/(?:[^w])(\/)/).pop();
   // otherwise, fall back to the kit layer name
   cleanedName = !cleanedName ? name : cleanedName;
   return cleanedName;
@@ -127,13 +127,13 @@ const parseOverrides = (layer, document) => {
         || overrideTypeName.toLowerCase() === 'radio'
         || overrideTypeName.toLowerCase() === 'type'
       ) {
-        // default icon name (usually last element of the name)
-        let iconName = overrideName.split('/').pop();
+        // default icon name (usually last element of the name, separated by “/”)
+        let iconName = overrideName.split(/(?:[^w])(\/)/).pop();
 
         // ---------- set up formatting exceptions
         // parsing exception for Ghost Entity symbols
         if (overrideTypeName.toLowerCase().includes('ghost')) {
-          iconName = overrideName.split('/').reverse()[1]; // eslint-disable-line prefer-destructuring
+          iconName = overrideName.split(/(?:[^w])(\/)/).reverse()[1]; // eslint-disable-line prefer-destructuring
         }
 
         // set final text

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -81,7 +81,7 @@ const checkNameForType = (name) => {
  */
 const cleanName = (name) => {
   // take only the last segment of the name (after a “/”, if available)
-
+  // ignore segments that begin with a “w” as-in “…Something w/ Icon”
   let cleanedName = name.split(/(?:[^w])(\/)/).pop();
   // otherwise, fall back to the kit layer name
   cleanedName = !cleanedName ? name : cleanedName;
@@ -104,7 +104,8 @@ const cleanName = (name) => {
 const parseOverrides = (layer, document, workingName = null) => {
   const overridesText = [];
 
-  // iterate available overrides
+  // iterate available overrides - based on current Lingo naming schemes and may break
+  // as those change or are updated.
   fromNative(layer).overrides.forEach((override) => {
     // only worry about an editable override that has changed and is based on a symbol
     if (
@@ -137,7 +138,7 @@ const parseOverrides = (layer, document, workingName = null) => {
           || overrideTypeName.toLowerCase() === 'radio'
           || overrideTypeName.toLowerCase() === 'type'
           || overrideTypeName.toLowerCase().includes('pebble')
-          || !override.path.includes('/')
+          || !override.path.includes('/') // excluding “/” gives us top-level overrides
         ) {
           // default icon name (usually last element of the name, separated by “/”)
           let overrideValueName = overrideName.split(/(?:[^w])(\/)/).pop();
@@ -146,8 +147,8 @@ const parseOverrides = (layer, document, workingName = null) => {
           // ---------- set up formatting exceptions
           // parsing exception for Ghost Entity symbols
           if (overrideTypeName.toLowerCase().includes('ghost')) {
-            // in some kits, Ghost naming scheme is fine
-            // but in the Web kit it is reversed: “…/Article Ghost/3” instead of “…/3/Article Ghost”
+            // in some kits, Ghost naming scheme is fine but in the Web kit it
+            // is reversed: “…/Article Ghost/3” instead of “…/3/Article Ghost”
             if (Number(overrideValueName) === parseInt(overrideValueName, 10)) {
               overrideValueName = overrideName.split('/').reverse()[1]; // eslint-disable-line prefer-destructuring
             }

--- a/src/Identifier.js
+++ b/src/Identifier.js
@@ -136,7 +136,11 @@ const parseOverrides = (layer, document) => {
         // ---------- set up formatting exceptions
         // parsing exception for Ghost Entity symbols
         if (overrideTypeName.toLowerCase().includes('ghost')) {
-          iconName = overrideName.split(/(?:[^w])(\/)/).reverse()[1]; // eslint-disable-line prefer-destructuring
+          // in some kits, Ghost naming scheme is fine
+          // but in the Web kit it is reversed: “…/Article Ghost/3” instead of “…/3/Article Ghost”
+          if (Number(iconName) === parseInt(iconName, 10)) {
+            iconName = overrideName.split('/').reverse()[1]; // eslint-disable-line prefer-destructuring
+          }
         }
 
         // set final text

--- a/src/main.js
+++ b/src/main.js
@@ -64,6 +64,7 @@ const annotateLayer = (context = null) => {
     // set up Identifier instance for the layer
     const layerToAnnotate = new Identifier({
       for: layer,
+      document,
       documentData,
       messenger,
     });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Annotate and spec design system elements",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "appcast": "https://raw.githubusercontent.com/linkedinlabs/sketch-auto-spec/master/.appcast.xml",
   "compatibleVersion": "55.0",


### PR DESCRIPTION
Watches the overrides on a Lingo Kit-connected Symbol and displays additional information in a couple scenarios:

1. If any top-level overrides have been changed
2. If an icon override has been changed

The override(s) are listed on a second line below the master symbol name from the Lingo Kit. An attempt is made to prevent duplicate names from showing up on the second line, but the naming system in the Lingo Kits is a bit inconsistent.