### PR TITLE
Annotate Within Groups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-specter",
-  "version": "0.0.17",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sketch-specter",
   "description": "A Sketch plugin for easily spec’ing design system elements.",
-  "version": "0.0.17",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/linkedinlabs/sketch-auto-spec.git"

--- a/src/Crawler.js
+++ b/src/Crawler.js
@@ -29,14 +29,31 @@ export default class Crawler {
   }
 
   /**
-   * @description Uses `setArray` to ensure the selection array is a javascript array.
+   * @description Uses `setArray` to ensure the selection array is a javascript array. Also
+   * looks into the selection for any groups and pulls out individual layers.
    *
    * @kind function
    * @name all
    * @returns {Object} All items in the array as a javascript array.
    */
   all() {
-    return setArray(this.array);
+    const initialSelection = setArray(this.array);
+    const flatSelection = [];
+    initialSelection.forEach((layer) => {
+      if (fromNative(layer).type === 'Group') {
+        const innerLayers = layer.children();
+        innerLayers.forEach((innerLayer) => {
+          // .children() includes the outer layer group, so we want to exclude it
+          // from our flattened selection
+          if (fromNative(innerLayer).type !== 'Group') {
+            flatSelection.push(innerLayer);
+          }
+        });
+      } else {
+        flatSelection.push(layer);
+      }
+    });
+    return flatSelection;
   }
 
   /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Annotate and spec design system elements",
   "author": "LinkedIn Labs",
   "homepage": "https://github.com/linkedinlabs/sketch-auto-spec",
-  "version": "0.0.17",
+  "version": "1.0.0",
   "identifier": "com.linkedinlabs.sketch.auto-spec-plugin",
   "appcast": "https://raw.githubusercontent.com/linkedinlabs/sketch-auto-spec/master/.appcast.xml",
   "compatibleVersion": "55.0",


### PR DESCRIPTION
Look _inside_ layer groups to build on `Crawler`’s `all()` selection.